### PR TITLE
Fix for UIORG-29

### DIFF
--- a/settings/Locale.js
+++ b/settings/Locale.js
@@ -70,6 +70,7 @@ class Locale extends React.Component {
       // Setting has been set previously: replace it
       this.props.mutator.recordId.replace(record.id);
       record.value = value;
+      delete record.metadata;
       this.props.mutator.setting.PUT(record);
     } else {
       // No setting: create a new one


### PR DESCRIPTION
Hi there, I saw the same issue as described in UIORG-29 in our demo environment (error thrown when changing locale). Debugged and figured out that "metadata" property is not accepted anymore by backend mod-configuration due to schema change.