### PR TITLE
don't use react-bootstrap's Row, Col. Refs STRIPES-427

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,6 @@
     "lodash": "^4.17.4",
     "prop-types": "^15.6.0",
     "react": "^15.4.2",
-    "react-bootstrap": "^0.30.7",
     "react-intl": "^2.3.0",
     "react-router-dom": "^4.0.0"
   },

--- a/settings/Bindings.js
+++ b/settings/Bindings.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Row, Col } from 'react-bootstrap';
 import { FormattedMessage } from 'react-intl';
 import Pane from '@folio/stripes-components/lib/Pane';
 import TextArea from '@folio/stripes-components/lib/TextArea';
+import { Row, Col } from '@folio/stripes-components/lib/LayoutGrid';
 
 
 class Bindings extends React.Component {

--- a/settings/Locale.js
+++ b/settings/Locale.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Row, Col } from 'react-bootstrap';
 import { FormattedMessage } from 'react-intl';
 import Pane from '@folio/stripes-components/lib/Pane';
 import Select from '@folio/stripes-components/lib/Select';
+import { Row, Col } from '@folio/stripes-components/lib/LayoutGrid';
 
 
 const options = [

--- a/settings/Plugins.js
+++ b/settings/Plugins.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Row, Col } from 'react-bootstrap';
 import Pane from '@folio/stripes-components/lib/Pane';
+import { Row, Col } from '@folio/stripes-components/lib/LayoutGrid';
 import { modules } from 'stripes-loader'; // eslint-disable-line
 import PluginType from './PluginType';
 

--- a/settings/SSOSettings.js
+++ b/settings/SSOSettings.js
@@ -1,7 +1,7 @@
 /* eslint-env browser */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Row, Col } from 'react-bootstrap';
+import { Row, Col } from '@folio/stripes-components/lib/LayoutGrid';
 import Pane from '@folio/stripes-components/lib/Pane';
 import TextField from '@folio/stripes-components/lib/TextField';
 import Button from '@folio/stripes-components/lib/Button';


### PR DESCRIPTION
Old versions of react-bootstrap barf up the `Warning: Accessing PropTypes via the main React package is deprecated...` message. We could just upgrade, but are working to deprecate react-bootstrap anyway.