### PR TITLE
separate params from path. Refs UIORG-69

### DIFF
--- a/settings/LocationLocations/LocationManager.js
+++ b/settings/LocationLocations/LocationManager.js
@@ -53,17 +53,29 @@ class LocationManager extends React.Component {
     },
     institutions: {
       type: 'okapi',
-      path: 'location-units/institutions?query=cql.allRecords=1 sortby name&limit=100',
+      path: 'location-units/institutions',
+      params: {
+        query: 'cql.allRecords=1 sortby name',
+        limit: '100',
+      },
       records: 'locinsts',
     },
     campuses: {
       type: 'okapi',
-      path: 'location-units/campuses?query=cql.allRecords=1 sortby name&limit=100',
+      path: 'location-units/campuses',
+      params: {
+        query: 'cql.allRecords=1 sortby name',
+        limit: '100',
+      },
       records: 'loccamps',
     },
     libraries: {
       type: 'okapi',
-      path: 'location-units/libraries?query=cql.allRecords=1 sortby name&limit=100',
+      path: 'location-units/libraries',
+      params: {
+        query: 'cql.allRecords=1 sortby name',
+        limit: '100',
+      },
       records: 'loclibs',
     },
 


### PR DESCRIPTION
A resource's path and params values should be handled separately so as
to avoid problems URL encoding, joining multiple parameters, etc. It's
possible to just tack the params onto the path and hope that no other
operation comes along and tries to amend the query string, but this is
exploiting a loophole, not good design.

Hattip @skomorokh / #49