### PR TITLE
Improve parens handling around institution codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * Remove fee fine owner from service points settings page. Fixes UIORG-74.
 * Additional location fields. Refs UIORG-69.
 * Add location permission set. Fixes UIORG-76.
+* Better parens handling for institutions. Refs UIORG-69.
 
 ## [2.2.0](https://github.com/folio-org/ui-organization/tree/v2.2.0) (2017-09-01)
 [Full Changelog](https://github.com/folio-org/ui-organization/compare/v2.1.0...v2.2.0)

--- a/settings/LocationCampuses.js
+++ b/settings/LocationCampuses.js
@@ -64,7 +64,7 @@ class LocationCampuses extends React.Component {
     const { formatMessage } = this.props.stripes.intl;
     const institutions = [];
     (((this.props.resources.institutions || {}).records || []).forEach(i => {
-      institutions.push({ value: i.id, label: `${i.name} ${i.code}` });
+      institutions.push({ value: i.id, label: `${i.name}${i.code ? ` (${i.code})` : ''}` });
     }));
 
     if (!institutions.length) {

--- a/settings/LocationLibraries.js
+++ b/settings/LocationLibraries.js
@@ -57,7 +57,7 @@ class LocationLibraries extends React.Component {
 
     const institutions = [];
     (((this.props.resources.institutions || {}).records || []).forEach(i => {
-      institutions.push({ value: i.id, label: `${i.name} ${i.code}` });
+      institutions.push({ value: i.id, label: `${i.name}${i.code ? ` (${i.code})` : ''}` });
     }));
 
     if (!institutions.length) {
@@ -67,7 +67,7 @@ class LocationLibraries extends React.Component {
     const campuses = [];
     ((this.props.resources.campuses || {}).records || []).forEach(i => {
       if (i.institutionId === this.state.institutionId) {
-        campuses.push({ value: i.id, label: `${i.name} ${i.code}` });
+        campuses.push({ value: i.id, label: `${i.name}${i.code ? ` (${i.code})` : ''}` });
       }
     });
 

--- a/settings/LocationLocations/LocationForm.js
+++ b/settings/LocationLocations/LocationForm.js
@@ -198,7 +198,7 @@ class LocationForm extends React.Component {
 
     const institutions = [];
     ((resources.institutions || {}).records || []).forEach(i => {
-      institutions.push({ value: i.id, label: `${i.name} ${i.code}` });
+      institutions.push({ value: i.id, label: `${i.name} ${i.code ? `(${i.code})` : ''}` });
     });
 
     // massage the "details" property which is represented in the API as
@@ -251,9 +251,8 @@ class LocationForm extends React.Component {
                   <CampusField
                     list={(resources.campuses || {}).records || []}
                     filterFieldId="institutionId"
-                    formatter={(i) => `${i.name} (${i.code})`}
+                    formatter={(i) => `${i.name}${i.code ? ` (${i.code})` : ''}`}
                     initialOption={{ label: this.translate('campuses.selectCampus') }}
-
                     label={`${this.translate('campuses.campus')} *`}
                     name="campusId"
                     id="input-location-campus"
@@ -269,7 +268,7 @@ class LocationForm extends React.Component {
                   <LibraryField
                     list={(resources.libraries || {}).records || []}
                     filterFieldId="campusId"
-                    formatter={(i) => `${i.name} (${i.code})`}
+                    formatter={(i) => `${i.name}${i.code ? ` (${i.code})` : ''}`}
                     initialOption={{ label: this.translate('libraries.selectLibrary') }}
                     label={`${this.translate('libraries.library')} *`}
                     name="libraryId"


### PR DESCRIPTION
Parens were always missing around institution codes on the
location-form, but no longer. Additionally, parens were always included,
even when codes were not present, after campuses and libraries, but no
longer.

Refs [UIORG-69](https://issues.folio.org/browse/UIORG-69)