### PR TITLE
UIORG-89 sync document lang attribute with tenant locale setting

### DIFF
--- a/settings/Locale.js
+++ b/settings/Locale.js
@@ -62,7 +62,11 @@ class Locale extends React.Component {
     const localeValues = JSON.parse(setting.value);
     const { locale, timezone } = localeValues;
     setTimeout(() => {
-      if (locale) this.props.stripes.setLocale(locale);
+      if (locale) {
+        this.props.stripes.setLocale(locale);
+        // update lang attribute on html tag.
+        document.documentElement.setAttribute('lang', locale.substr(0, 2));
+      }
       if (timezone) this.props.stripes.setTimezone(timezone);
     }, 2000);
   }


### PR DESCRIPTION
# Purpose
When setting the tenant locale, the document's `lang` attribute on the `<html>` tag should be updated to reflect the change.

# Approach
Added a single line of vanilla js to update the attribute when settings are saved.