### PR TITLE
STCOM-284 Update stripes-components paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "webpack": "1.11.0"
   },
   "dependencies": {
-    "@folio/stripes-components": "^2.0.14",
+    "@folio/stripes-components": "^2.0.20",
     "@folio/stripes-core": "^2.9.4",
     "@folio/stripes-form": "^0.8.0",
     "@folio/stripes-smart-components": "^1.4.12",

--- a/settings/LocationLocations/DetailsField.js
+++ b/settings/LocationLocations/DetailsField.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import TextField from '@folio/stripes-components/lib/TextField';
-import RepeatableField from '@folio/stripes-components/lib/structures/RepeatableField';
+import RepeatableField from '@folio/stripes-components/lib/RepeatableField';
 
 const DetailsField = ({ translate }) => {
   return (

--- a/settings/LocationLocations/LocationForm.js
+++ b/settings/LocationLocations/LocationForm.js
@@ -14,7 +14,7 @@ import IfPermission from '@folio/stripes-components/lib/IfPermission';
 import IconButton from '@folio/stripes-components/lib/IconButton';
 import Icon from '@folio/stripes-components/lib/Icon';
 import SafeHTMLMessage from '@folio/react-intl-safe-html';
-import ConfirmationModal from '@folio/stripes-components/lib/structures/ConfirmationModal';
+import ConfirmationModal from '@folio/stripes-components/lib/ConfirmationModal';
 import { Row, Col } from '@folio/stripes-components/lib/LayoutGrid';
 import { Accordion, ExpandAllButton } from '@folio/stripes-components/lib/Accordion';
 import ViewMetaData from '@folio/stripes-smart-components/lib/ViewMetaData';

--- a/settings/ServicePoints/ServicePointForm.js
+++ b/settings/ServicePoints/ServicePointForm.js
@@ -15,7 +15,7 @@ import IconButton from '@folio/stripes-components/lib/IconButton';
 import Icon from '@folio/stripes-components/lib/Icon';
 
 // eslint-disable-next-line import/no-unresolved
-import ConfirmationModal from '@folio/stripes-components/lib/structures/ConfirmationModal';
+import ConfirmationModal from '@folio/stripes-components/lib/ConfirmationModal';
 import { Row, Col } from '@folio/stripes-components/lib/LayoutGrid';
 import { Accordion, ExpandAllButton } from '@folio/stripes-components/lib/Accordion';
 import ViewMetaData from '@folio/stripes-smart-components/lib/ViewMetaData';


### PR DESCRIPTION
https://issues.folio.org/browse/STCOM-284

Components previously found in `@folio/stripes-components/lib/structures` are now at `@folio/stripes-components/lib`.