### PR TITLE
refresh lookup tables on mount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * Add location permission set. Fixes UIORG-76.
 * Better parens handling for institutions. Refs UIORG-69.
 * Include location-count on libraries page. Refs UIORG-66.
+* Refresh lookup tables on mount. Refs UIORG-69.
 
 ## [2.2.0](https://github.com/folio-org/ui-organization/tree/v2.2.0) (2017-09-01)
 [Full Changelog](https://github.com/folio-org/ui-organization/compare/v2.1.0...v2.2.0)
@@ -90,4 +91,3 @@
 ## [0.1.0](https://github.com/folio-org/ui-organization/tree/v0.1.0) (2017-05-05)
 
 * The first formal release.
-

--- a/settings/LocationLocations/LocationManager.js
+++ b/settings/LocationLocations/LocationManager.js
@@ -30,6 +30,18 @@ class LocationManager extends React.Component {
         PUT: PropTypes.func,
         DELETE: PropTypes.func,
       }),
+      institutions: PropTypes.shape({
+        GET: PropTypes.func.isRequired,
+        reset: PropTypes.func.isRequired,
+      }),
+      campuses: PropTypes.shape({
+        GET: PropTypes.func.isRequired,
+        reset: PropTypes.func.isRequired,
+      }),
+      libraries: PropTypes.shape({
+        GET: PropTypes.func.isRequired,
+        reset: PropTypes.func.isRequired,
+      }),
       uniquenessValidator: PropTypes.object,
     }).isRequired,
     stripes: PropTypes.shape({
@@ -59,6 +71,7 @@ class LocationManager extends React.Component {
         limit: '100',
       },
       records: 'locinsts',
+      accumulate: true,
     },
     campuses: {
       type: 'okapi',
@@ -68,6 +81,7 @@ class LocationManager extends React.Component {
         limit: '100',
       },
       records: 'loccamps',
+      accumulate: true,
     },
     libraries: {
       type: 'okapi',
@@ -77,8 +91,8 @@ class LocationManager extends React.Component {
         limit: '100',
       },
       records: 'loclibs',
+      accumulate: true,
     },
-
   });
 
   constructor(props) {
@@ -87,6 +101,19 @@ class LocationManager extends React.Component {
     this.validate = this.validate.bind(this);
     this.asyncValidate = this.asyncValidate.bind(this);
     this.connectedLocationDetail = props.stripes.connect(LocationDetail);
+  }
+
+  /**
+   * Refresh lookup tables when the component mounts. Fetches in the manifest
+   * will only run once (in the constructor) but because this object may be
+   * unmounted/remounted without being destroyed/recreated, the lookup tables
+   * will be stale if they change between unmounting/remounting.
+   */
+  componentDidMount() {
+    ['institutions', 'campuses', 'libraries'].forEach(i => {
+      this.props.mutator[i].reset();
+      this.props.mutator[i].GET();
+    });
   }
 
   translate(id) {


### PR DESCRIPTION
Refresh lookup tables each time the component mounts. 

Queries in the manifest only run in the constructor, but this component may be unmounted/remounted without being destroyed/recreated, which means lookup tables will be stale if they change between unmount/remount. This scenario is described in the [comments](https://issues.folio.org/browse/UIORG-69?focusedCommentId=30161&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-30161) of UIORG-69.

Refs [UIORG-69](https://issues.folio.org/browse/UIORG-69)