### PR TITLE
Refresh lookup tables each time component mounts

### DIFF
--- a/settings/LocationCampuses.js
+++ b/settings/LocationCampuses.js
@@ -21,6 +21,12 @@ class LocationCampuses extends React.Component {
         records: PropTypes.arrayOf(PropTypes.object),
       }),
     }),
+    mutator: PropTypes.shape({
+      institutions: PropTypes.shape({
+        GET: PropTypes.func.isRequired,
+        reset: PropTypes.func.isRequired,
+      }),
+    }),
   };
 
   static manifest = {
@@ -28,6 +34,7 @@ class LocationCampuses extends React.Component {
       type: 'okapi',
       records: 'locinsts',
       path: 'location-units/institutions?query=cql.allRecords=1 sortby name&limit=100',
+      accumulate: true,
     },
     locationsPerCampus: {
       type: 'okapi',
@@ -46,6 +53,17 @@ class LocationCampuses extends React.Component {
     this.state = {
       institutionId: null,
     };
+  }
+
+  /**
+   * Refresh lookup tables when the component mounts. Fetches in the manifest
+   * will only run once (in the constructor) but because this object may be
+   * unmounted/remounted without being destroyed/recreated, the lookup tables
+   * will be stale if they change between unmounting/remounting.
+   */
+  componentDidMount() {
+    this.props.mutator.institutions.reset();
+    this.props.mutator.institutions.GET();
   }
 
   numberOfObjectsFormatter = (item) => {

--- a/settings/LocationLibraries.js
+++ b/settings/LocationLibraries.js
@@ -14,6 +14,16 @@ class LocationLibraries extends React.Component {
       campuses: PropTypes.object,
       locationsPerLibrary: PropTypes.object,
     }).isRequired,
+    mutator: PropTypes.shape({
+      institutions: PropTypes.shape({
+        GET: PropTypes.func.isRequired,
+        reset: PropTypes.func.isRequired,
+      }),
+      campuses: PropTypes.shape({
+        GET: PropTypes.func.isRequired,
+        reset: PropTypes.func.isRequired,
+      }),
+    }),
   };
 
   static manifest = Object.freeze({
@@ -21,11 +31,13 @@ class LocationLibraries extends React.Component {
       type: 'okapi',
       records: 'locinsts',
       path: 'location-units/institutions?query=cql.allRecords=1 sortby name&limit=100',
+      accumulate: true,
     },
     campuses: {
       type: 'okapi',
       records: 'loccamps',
-      path: 'location-units/campuses?query=cql.allRecords=1 sortby name&limit=100'
+      path: 'location-units/campuses?query=cql.allRecords=1 sortby name&limit=100',
+      accumulate: true,
     },
     locationsPerLibrary: {
       type: 'okapi',
@@ -43,6 +55,19 @@ class LocationLibraries extends React.Component {
       institutionId: null,
       campusId: null,
     };
+  }
+
+  /**
+   * Refresh lookup tables when the component mounts. Fetches in the manifest
+   * will only run once (in the constructor) but because this object may be
+   * unmounted/remounted without being destroyed/recreated, the lookup tables
+   * will be stale if they change between unmounting/remounting.
+   */
+  componentDidMount() {
+    ['institutions', 'campuses'].forEach(i => {
+      this.props.mutator[i].reset();
+      this.props.mutator[i].GET();
+    });
   }
 
   numberOfObjectsFormatter = (item) => {


### PR DESCRIPTION
Queries in the manifest only run in the constructor, but this
component may be unmounted/remounted without being
destroyed/recreated, which means lookup tables will be stale
if they change between unmount/remount. This scenario is
described in the comments of UIORG-69.

Refs [UIORG-69](https://issues.folio.org/browse/UIORG-69)