### PR TITLE
refactor away stripes-components/lib/structures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * Better parens handling for institutions. Refs UIORG-69.
 * Include location-count on libraries page. Refs UIORG-66.
 * Refresh lookup tables on mount. Refs UIORG-69.
+* Refactoring away structures. Refs STCOM-277.
 
 ## [2.2.0](https://github.com/folio-org/ui-organization/tree/v2.2.0) (2017-09-01)
 [Full Changelog](https://github.com/folio-org/ui-organization/compare/v2.1.0...v2.2.0)

--- a/settings/LocationLocations/DetailsField.js
+++ b/settings/LocationLocations/DetailsField.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import TextField from '@folio/stripes-components/lib/TextField';
-import RepeatableField from '@folio/stripes-components/lib/structures/RepeatableField';
+import RepeatableField from '@folio/stripes-components/lib/RepeatableField';
 
 const DetailsField = ({ translate }) => {
   return (

--- a/settings/LocationLocations/LocationForm.js
+++ b/settings/LocationLocations/LocationForm.js
@@ -14,7 +14,7 @@ import IfPermission from '@folio/stripes-components/lib/IfPermission';
 import IconButton from '@folio/stripes-components/lib/IconButton';
 import Icon from '@folio/stripes-components/lib/Icon';
 import SafeHTMLMessage from '@folio/react-intl-safe-html';
-import ConfirmationModal from '@folio/stripes-components/lib/structures/ConfirmationModal';
+import ConfirmationModal from '@folio/stripes-components/lib/ConfirmationModal';
 import { Row, Col } from '@folio/stripes-components/lib/LayoutGrid';
 import { Accordion, ExpandAllButton } from '@folio/stripes-components/lib/Accordion';
 import ViewMetaData from '@folio/stripes-smart-components/lib/ViewMetaData';


### PR DESCRIPTION
`lib/structures` has been deprecated in favor of `lib/`.

Refs [STCOM-277](https://issues.folio.org/browse/STCOM-277)