### PR TITLE
add user permissions to permission set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * Refresh lookup tables on mount. Refs UIORG-69.
 * Refactoring away structures. Refs STCOM-277.
 * Refresh location counts on mount. Refs UIORG-60, UIORG-63, UIORG-66.
+* Add user-permissions to location permission set for their metadata. Refs UIORG-76.
 
 ## [2.2.0](https://github.com/folio-org/ui-organization/tree/v2.2.0) (2017-09-01)
 [Full Changelog](https://github.com/folio-org/ui-organization/compare/v2.1.0...v2.2.0)

--- a/package.json
+++ b/package.json
@@ -69,6 +69,9 @@
           "configuration.all",
           "settings.organization.enabled",
 
+          "users.item.get",
+          "users.collection.get",
+
           "inventory-storage.location-units.institutions.collection.get",
           "inventory-storage.location-units.institutions.item.get",
           "inventory-storage.location-units.institutions.item.post",


### PR DESCRIPTION
Add user-related permissions to the location-management permission set
so users can see last-updated-by details.

Refs [UIORG-76](https://issues.folio.org/browse/UIORG-76)