### PR TITLE
suppress ControlledVocab without filter selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * Refactoring away structures. Refs STCOM-277.
 * Refresh location counts on mount. Refs UIORG-60, UIORG-63, UIORG-66.
 * Add user-permissions to location permission set for their metadata. Refs UIORG-76.
+* Hide Campus and Library CRUD panels until Institution and Campus filters are valid. Refs UIORG-82, UIORG-83.
 
 ## [2.2.0](https://github.com/folio-org/ui-organization/tree/v2.2.0) (2017-09-01)
 [Full Changelog](https://github.com/folio-org/ui-organization/compare/v2.1.0...v2.2.0)

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
   },
   "scripts": {
     "lint": "eslint *.js settings",
-    "test": "echo 'placeholder. no tests implemented'"
+    "test": "(cd ../ui-testing; yarn test-module -- -o --run=organization --host=localhost)"
   },
   "devDependencies": {
     "@folio/eslint-config-stripes": "^1.1.0",
@@ -127,7 +127,7 @@
     "@folio/stripes-components": "^2.0.20",
     "@folio/stripes-core": "^2.9.4",
     "@folio/stripes-form": "^0.8.0",
-    "@folio/stripes-smart-components": "^1.4.12",
+    "@folio/stripes-smart-components": "^1.4.16",
     "@folio/react-intl-safe-html": "^1.0.1",
     "lodash": "^4.17.4",
     "prop-types": "^15.6.0",

--- a/settings/LocationCampuses.js
+++ b/settings/LocationCampuses.js
@@ -124,6 +124,9 @@ class LocationCampuses extends React.Component {
         nameKey="group"
         id="patrongroups"
         preCreateHook={(item) => Object.assign({}, item, { institutionId: this.state.institutionId })}
+        listSuppressor={() => !this.state.institutionId}
+        listSuppressorText={this.props.stripes.intl.formatMessage({ id: 'ui-organization.settings.location.campuses.missingSelection' })}
+
       />
     );
   }

--- a/settings/LocationLibraries.js
+++ b/settings/LocationLibraries.js
@@ -154,6 +154,8 @@ class LocationLibraries extends React.Component {
         nameKey="group"
         id="patrongroups"
         preCreateHook={(item) => Object.assign({}, item, { campusId: this.state.campusId })}
+        listSuppressor={() => !(this.state.institutionId && this.state.campusId)}
+        listSuppressorText={this.props.stripes.intl.formatMessage({ id: 'ui-organization.settings.location.libraries.missingSelection' })}
       />
     );
   }

--- a/translations/ui-organization/en.json
+++ b/translations/ui-organization/en.json
@@ -36,10 +36,12 @@
   "settings.location.campuses": "Campuses",
   "settings.location.campuses.campus": "Campus",
   "settings.location.campuses.selectCampus": "Select campus",
+  "settings.location.campuses.missingSelection": "Please select an institution to continue.",
 
   "settings.location.libraries": "Libraries",
   "settings.location.libraries.library": "Library",
   "settings.location.libraries.selectLibrary": "Select library",
+  "settings.location.libraries.missingSelection": "Please select an institution and campus to continue.",
 
   "settings.location.locations": "Locations",
   "settings.location.locations.location": "Location",


### PR DESCRIPTION
Hide the `ControlledVocab` panel unless a valid selection has been made
from the Institution and Campus filters.

Refs [UIORG-82](https://issues.folio.org/browse/UIORG-82), [UIORG-83](https://issues.folio.org/browse/UIORG-83)