### PR TITLE
fix the typos

### DIFF
--- a/settings/LocationCampuses.js
+++ b/settings/LocationCampuses.js
@@ -122,7 +122,7 @@ class LocationCampuses extends React.Component {
         }}
         formatter={{ numberOfObjects: this.numberOfObjectsFormatter }}
         nameKey="group"
-        id="patrongroups"
+        id="campuses"
         preCreateHook={(item) => Object.assign({}, item, { institutionId: this.state.institutionId })}
       />
     );

--- a/settings/LocationLibraries.js
+++ b/settings/LocationLibraries.js
@@ -152,7 +152,7 @@ class LocationLibraries extends React.Component {
         }}
         formatter={formatter}
         nameKey="group"
-        id="patrongroups"
+        id="libraries"
         preCreateHook={(item) => Object.assign({}, item, { campusId: this.state.campusId })}
       />
     );

--- a/settings/LocationLocations/LocationForm.js
+++ b/settings/LocationLocations/LocationForm.js
@@ -70,6 +70,9 @@ class LocationForm extends React.Component {
     // massage the "details" property which is represented in the API as
     // an object but on the form as an array of key-value pairs
     const detailsObject = {};
+    if (!data.detailsArray) {
+      data.detailsArray = [];
+    }
     data.detailsArray.forEach(i => {
       detailsObject[i.name] = i.value;
     });
@@ -281,12 +284,12 @@ class LocationForm extends React.Component {
               </Row>
               <Row>
                 <Col xs={8}>
-                  <Field label={this.translate('locations.name')} name="name" id="input-location-name" component={TextField} fullWidth disabled={disabled} />
+                  <Field label={`${this.translate('locations.name')} *`} name="name" id="input-location-name" component={TextField} fullWidth disabled={disabled} />
                 </Col>
               </Row>
               <Row>
                 <Col xs={8}>
-                  <Field label={this.translate('code')} name="code" id="input-location-code" component={TextField} fullWidth disabled={disabled} />
+                  <Field label={`${this.translate('code')} *`} name="code" id="input-location-code" component={TextField} fullWidth disabled={disabled} />
                 </Col>
               </Row>
               <Row>


### PR DESCRIPTION
Some required fields were not correctly labeled. Some element IDs were
clearly cut-and-pasted from other elements and now reflect the elements
they pertain to.