### PR TITLE
make stripes-core a peerDependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * Location managment tests!
 * Refactor asyncValidation so failures persist through blurs. Refs UIORG-69.
 * Assign locations to service points. Fixes UIORG-90.
+* stripes-core MUST be a peer-dep to avoid dupes in the bundle. Dupes are bad.
 
 ## [2.2.0](https://github.com/folio-org/ui-organization/tree/v2.2.0) (2017-09-01)
 [Full Changelog](https://github.com/folio-org/ui-organization/compare/v2.1.0...v2.2.0)

--- a/package.json
+++ b/package.json
@@ -126,7 +126,6 @@
   },
   "dependencies": {
     "@folio/stripes-components": "^3.0.0",
-    "@folio/stripes-core": "^2.9.4",
     "@folio/stripes-form": "^0.8.0",
     "@folio/stripes-smart-components": "^1.4.16",
     "@folio/react-intl-safe-html": "^1.0.1",


### PR DESCRIPTION
stripes-core MUST be a peerDependency in order to ensure that only a
single copy of it exists in the bundle. Multiple copies mean the
provider and consumer of objects via the context API can have different
versions, which does not work. A provider cannot register a consumer
created with a different version.