### PR TITLE
prevent resource overwrite by EntryManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * Location managment tests!
 * Refactor asyncValidation so failures persist through blurs. Refs UIORG-69.
 * Assign locations to service points. Fixes UIORG-90.
+* Pass manager resources with alternative props name.
 
 ## [2.2.0](https://github.com/folio-org/ui-organization/tree/v2.2.0) (2017-09-01)
 [Full Changelog](https://github.com/folio-org/ui-organization/compare/v2.1.0...v2.2.0)

--- a/settings/LocationLocations/LocationForm.js
+++ b/settings/LocationLocations/LocationForm.js
@@ -31,7 +31,7 @@ class LocationForm extends React.Component {
       connect: PropTypes.func.isRequired,
       intl: PropTypes.object.isRequired,
     }).isRequired,
-    resources: PropTypes.shape({
+    locationResources: PropTypes.shape({
       institutions: PropTypes.object,
       campuses: PropTypes.object,
       libraries: PropTypes.object,
@@ -188,7 +188,7 @@ class LocationForm extends React.Component {
   }
 
   render() {
-    const { stripes, handleSubmit, initialValues, resources } = this.props;
+    const { stripes, handleSubmit, initialValues, locationResources } = this.props;
     const loc = initialValues || {};
     const { confirmDelete, sections } = this.state;
     const disabled = !stripes.hasPerm('settings.organization.enabled');
@@ -200,7 +200,7 @@ class LocationForm extends React.Component {
     ];
 
     const institutions = [];
-    ((resources.institutions || {}).records || []).forEach(i => {
+    ((locationResources.institutions || {}).records || []).forEach(i => {
       institutions.push({ value: i.id, label: `${i.name} ${i.code ? `(${i.code})` : ''}` });
     });
 
@@ -252,7 +252,7 @@ class LocationForm extends React.Component {
               <Row>
                 <Col xs={12}>
                   <CampusField
-                    list={(resources.campuses || {}).records || []}
+                    list={(locationResources.campuses || {}).records || []}
                     filterFieldId="institutionId"
                     formatter={(i) => `${i.name}${i.code ? ` (${i.code})` : ''}`}
                     initialOption={{ label: this.translate('campuses.selectCampus') }}
@@ -269,7 +269,7 @@ class LocationForm extends React.Component {
               <Row>
                 <Col xs={12}>
                   <LibraryField
-                    list={(resources.libraries || {}).records || []}
+                    list={(locationResources.libraries || {}).records || []}
                     filterFieldId="campusId"
                     formatter={(i) => `${i.name}${i.code ? ` (${i.code})` : ''}`}
                     initialOption={{ label: this.translate('libraries.selectLibrary') }}

--- a/settings/LocationLocations/LocationManager.js
+++ b/settings/LocationLocations/LocationManager.js
@@ -187,6 +187,7 @@ class LocationManager extends React.Component {
       <EntryManager
         {...this.props}
         parentMutator={this.props.mutator}
+        locationResources={this.props.resources}
         entryList={sortBy((this.props.resources.entries || {}).records || [], ['name'])}
         detailComponent={this.connectedLocationDetail}
         paneTitle={this.props.label}


### PR DESCRIPTION
When EntryManager was refactored into EntryWrapper and EntryManager to
get URL resources working, that had the side effect of overwriting the
resources property if resources were passed in via props. To be fair,
passing in resources withouth renaming the prop was really stupid. Now,
it's less stupid, so it works.