### PR TITLE
pass id prop to ConfirmationModal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 * Pass manager resources with alternative props name.
 * stripes-core MUST be a peer-dep to avoid dupes in the bundle. Dupes are bad.
 * Assign locations to service points. Fixes UIORG-90.
+* Provide an id prop to `<ConfirmationModal>` to avoid it autogenerating one for us. Refs STCOM-317.
 
 ## [2.2.0](https://github.com/folio-org/ui-organization/tree/v2.2.0) (2017-09-01)
 [Full Changelog](https://github.com/folio-org/ui-organization/compare/v2.1.0...v2.2.0)

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
   "dependencies": {
     "@folio/stripes-components": "^3.0.0",
     "@folio/stripes-form": "^0.8.0",
-    "@folio/stripes-smart-components": "^1.4.16",
+    "@folio/stripes-smart-components": "^1.4.22",
     "@folio/react-intl-safe-html": "^1.0.1",
     "lodash": "^4.17.4",
     "prop-types": "^15.6.0",

--- a/settings/LocationLocations/LocationForm.js
+++ b/settings/LocationLocations/LocationForm.js
@@ -317,6 +317,7 @@ class LocationForm extends React.Component {
               <DetailsField translate={this.translate} />
             </Accordion>
             <ConfirmationModal
+              id="deletelocation-confirmation"
               open={confirmDelete}
               heading={this.translate('locations.deleteLocation')}
               message={confirmationMessage}

--- a/settings/ServicePoints/ServicePointForm.js
+++ b/settings/ServicePoints/ServicePointForm.js
@@ -244,6 +244,7 @@ class ServicePointForm extends React.Component {
             />
 
             <ConfirmationModal
+              id="deleteservicepoint-confirmation"
               open={confirmDelete}
               heading={this.translate('deleteServicePoint')}
               message={confirmationMessage}


### PR DESCRIPTION
Generation of HTML element-IDs in `<ConfirmationModal>` changed in
https://github.com/folio-org/stripes-components/commit/ce3ba8c996463a389ae3c3aeb36069d9a785ed69
and that broke a bunch of tests that relied on the old style of element
IDs. Happily, we can restore this behavior by passing in an ID prop that
matches the old format.

Refs [STCOM-317](https://issues.folio.org/browse/STCOM-317)