### PR TITLE
validation use of locations before removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 * Assign locations to service points. Fixes UIORG-90.
 * Provide an id prop to `<ConfirmationModal>` to avoid it autogenerating one for us. Refs STCOM-317.
 * In the location manager in the settings, fetch up to 40 locations (was 10), and sort them by name. Fixes UIORG-101.
+* Validate use of locations prior to deletion. Refs UIORG-86.
 
 ## [2.2.0](https://github.com/folio-org/ui-organization/tree/v2.2.0) (2017-09-01)
 [Full Changelog](https://github.com/folio-org/ui-organization/compare/v2.1.0...v2.2.0)

--- a/settings/LocationLocations/LocationManager.js
+++ b/settings/LocationLocations/LocationManager.js
@@ -55,6 +55,18 @@ class LocationManager extends React.Component {
       records: 'loclibs',
       accumulate: true,
     },
+    holdingsEntries: {
+      type: 'okapi',
+      path: 'holdings-storage/holdings',
+      records: 'holdingsRecords',
+      accumulate: true,
+    },
+    itemEntries: {
+      type: 'okapi',
+      path: 'inventory/items',
+      records: 'items',
+      accumulate: true,
+    }
   });
 
   static propTypes = {
@@ -92,6 +104,15 @@ class LocationManager extends React.Component {
         reset: PropTypes.func.isRequired,
       }),
       uniquenessValidator: PropTypes.object,
+      holdingsEntries: PropTypes.shape({
+        GET: PropTypes.func.isRequired,
+        reset: PropTypes.func.isRequired,
+      }),
+      itemEntries: PropTypes.shape({
+        GET: PropTypes.func.isRequired,
+        reset: PropTypes.func.isRequired,
+      }),
+
     }).isRequired,
     stripes: PropTypes.shape({
       intl: PropTypes.object.isRequired,


### PR DESCRIPTION
Check whether a location is in use by a holdings or item record before
attempting to remove it. This allows us to be more confident that a
DELETE request will be successful if we make it that far, and allows us
to show a nicer, more informative error message if we know such a
request would fail.

Refs [UIORG-86](https://issues.folio.org/browse/UIORG-86)