### PR TITLE
provide default isActive value to new locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-organization
 
+## 2.4.0 (IN PROGRESS)
+
+* Provide default `isActive` value for new locations. Fixes UIORG-109.
+
 ## [2.3.0](https://github.com/folio-org/ui-organization/tree/v2.3.0) (2017-09-06)
 [Full Changelog](https://github.com/folio-org/ui-organization/compare/v2.2.0...v2.3.0)
 

--- a/settings/LocationLocations/LocationManager.js
+++ b/settings/LocationLocations/LocationManager.js
@@ -150,7 +150,7 @@ class LocationManager extends React.Component {
   validate(values) {
     const errors = {};
 
-    const requiredFields = ['name', 'code', 'discoveryDisplayName', 'institutionId', 'campusId', 'libraryId'];
+    const requiredFields = ['name', 'code', 'discoveryDisplayName', 'institutionId', 'campusId', 'libraryId', 'isActive'];
     requiredFields.forEach(field => {
       if (!values[field]) {
         errors[field] = this.props.stripes.intl.formatMessage({ id: 'stripes-core.label.missingRequiredField' });
@@ -215,6 +215,7 @@ class LocationManager extends React.Component {
     return (
       <EntryManager
         {...this.props}
+        defaultEntry={{ isActive: true }}
         parentMutator={this.props.mutator}
         locationResources={this.props.resources}
         entryList={sortBy((this.props.resources.entries || {}).records || [], ['name'])}


### PR DESCRIPTION
It appears that under some circumstances redux-form will only submit
dirty form fields if a field was not provided to `props.initialValues`.
This is particularly relevant when creating new items because it means
that new item will not be correctly initialized if, say, the form has a
dropdown menu with a default selection.

https://github.com/erikras/redux-form/issues/701 may be relevant, at
least as far as understanding the behavior.

This behavior has never been observed locally but did appear reliably on
folio-testing. What a mystery.

Fixes [UIORG-109](https://issues.folio.org/browse/UIORG-109)