### PR TITLE
use current stripes-form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change history for ui-organization
 
+
+## 2.4.0 (IN PROGRESS)
+
+* Update to stripes-form 0.9.0. Refs STRIPES-556.
+
 ## [2.3.0](https://github.com/folio-org/ui-organization/tree/v2.3.0) (2017-09-06)
 [Full Changelog](https://github.com/folio-org/ui-organization/compare/v2.2.0...v2.3.0)
 

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
   },
   "dependencies": {
     "@folio/stripes-components": "^3.0.0",
-    "@folio/stripes-form": "^0.8.0",
+    "@folio/stripes-form": "^0.9.0",
     "@folio/stripes-smart-components": "^1.4.22",
     "@folio/react-intl-safe-html": "^1.0.1",
     "downshift": "^2.0.19",


### PR DESCRIPTION
Because stripes-form has not been released as a v1.0.x package,
this means ^0.8.0 is effectively ~0.8.0, meaning those packages
are locked at 0.8.x, not 0.x.x as intended. stripes-form 0.8.0
pulled in an old version of stripes-components which pulled in
an old version of React which brought darkness upon the land.

Refs [STRIPES-555](https://issues.folio.org/browse/STRIPES-555)