### PR TITLE
Copy RepeatableField from stripes-components

### DIFF
--- a/lib/RepeatableField/FieldRow.js
+++ b/lib/RepeatableField/FieldRow.js
@@ -1,0 +1,234 @@
+import React from 'react';
+import { intlShape } from 'react-intl';
+import PropTypes from 'prop-types';
+import uniqueId from 'lodash/uniqueId';
+import { Field } from 'redux-form';
+
+import injectIntl from '@folio/stripes-components/lib/InjectIntl';
+import Button from '@folio/stripes-components/lib/Button';
+import Layout from '@folio/stripes-components/lib/Layout';
+import Icon from '@folio/stripes-components/lib/Icon';
+import { Row, Col } from '@folio/stripes-components/lib/LayoutGrid';
+import omit from '@folio/stripes-components/util/omitProps';
+import SRStatus from '@folio/stripes-components/lib/SRStatus';
+import css from './RepeatableField.css';
+
+const FieldRowPropTypes = {
+  addButtonId: PropTypes.string,
+  addDefault: PropTypes.func,
+  addDefaultItem: PropTypes.bool,
+  addLabel: PropTypes.string,
+  containerRef: PropTypes.func,
+  fields: PropTypes.object,
+  formatter: PropTypes.func,
+  intl: intlShape.isRequired,
+  label: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+  lastRowRef: PropTypes.func,
+  newItemTemplate: PropTypes.object,
+  onAddField: PropTypes.func,
+  template: PropTypes.arrayOf(PropTypes.object),
+};
+
+class FieldRow extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.refIfLastRow = this.refIfLastRow.bind(this);
+    this.renderControl = this.renderControl.bind(this);
+    this.addButton = null;
+    this.srstatus = null;
+    this.action = null;
+
+    this.addButtonId = this.props.addButtonId || uniqueId(`${this.props.label}AddButton`);
+  }
+
+  componentDidMount() {
+    if (this.props.fields.length === 0 && this.props.addDefaultItem) {
+      setTimeout(() => { this.props.addDefault(this.props.fields); }, 5);
+    }
+  }
+
+  componentDidUpdate() {
+    const {
+      fields,
+      label
+    } = this.props;
+
+    if (this.action) {
+      if (this.action.type === 'add') {
+        this.srstatus.sendMessage(
+          `added new ${label} field. ${fields.length} ${label} total`
+        );
+        this.action = null;
+      }
+      if (this.action.type === 'remove') {
+        const { item } = this.action;
+        let contextualSpeech;
+        if (typeof item === 'string') {
+          contextualSpeech = this.action.item;
+        } else if (typeof item === 'object') {
+          const valueArray = [];
+          for (const key in item) {
+            if (typeof item[key] === 'string' && item[key].length < 25) {
+              valueArray.push(item[key]);
+            }
+          }
+          if (valueArray.length > 0) {
+            contextualSpeech = valueArray.join(' ');
+          } else {
+            contextualSpeech = this.action.index;
+          }
+        }
+        this.srstatus.sendMessage(
+          `${label} ${contextualSpeech} has been removed. ${fields.length} ${label} total`
+        );
+        this.action = null;
+        document.getElementById(this.addButtonId).focus();
+      }
+    }
+  }
+
+  handleRemove(index, item) {
+    this.action = { type: 'remove', item, index };
+    this.props.fields.remove(index);
+  }
+
+  handleAdd() {
+    this.action = { type: 'add' };
+  }
+
+  refIfLastRow(ref, index) {
+    const { fields } = this.props;
+    if (index === fields.length - 1) {
+      this.lastRow = ref;
+      this.props.lastRowRef(ref);
+    }
+  }
+
+  renderControl(fields, field, fieldIndex, template, templateIndex) {
+    if (template.render) {
+      return template.render({ fields, field, fieldIndex, templateIndex });
+    }
+
+    const { name, label, ...rest } = omit(template, ['component', 'render']);
+    const labelProps = {};
+    if (fieldIndex === 0) {
+      labelProps.label = label;
+    } else {
+      labelProps['aria-label'] = `${label} ${fieldIndex}`;
+    }
+    return (
+      <Field
+        name={name ? `${fields.name}[${fieldIndex}].${name}` : `${fields.name}[${fieldIndex}]`}
+        component={this.props.formatter}
+        templateIndex={templateIndex}
+        id={uniqueId(field)}
+        fullWidth
+        {...labelProps}
+        data-key={fieldIndex}
+        {...rest}
+      />
+    );
+  }
+
+  render() {
+    const { fields, intl } = this.props;
+    let addLabel = intl.formatMessage(
+      { id: 'stripes-components.addNewField' },
+      { item: this.props.label }
+    );
+    if (this.props.addLabel) {
+      addLabel = this.props.addLabel;
+    }
+
+    if (this.props.fields.length === 0 && !this.props.addDefaultItem) {
+      return (
+        <div ref={this.props.containerRef}>
+          <SRStatus ref={(ref) => { this.srstatus = ref; }} />
+          <fieldset>
+            <legend id={this._arrayId} className={css.RFLegend}>{this.props.label}</legend>
+            <Row>
+              <Col xs={12} sm={8}>
+                <Row>
+                  <Col xs={10}>
+                    <Button
+                      fullWidth
+                      style={{ marginBottom: '12px' }}
+                      onClick={() => { this.props.onAddField(fields); }}
+                      id={this.addButtonId}
+                    >
+                      {this.props.addLabel ? this.props.addLabel : `+ Add ${this.props.label}`}
+                    </Button>
+                  </Col>
+                </Row>
+              </Col>
+            </Row>
+          </fieldset>
+        </div>
+      );
+    }
+    return (
+      <div ref={this.props.containerRef}>
+        <SRStatus ref={(ref) => { this.srstatus = ref; }} />
+        <fieldset>
+          <legend id={this._arrayId} className={css.RFLegend}>{this.props.label}</legend>
+
+          {fields.map((f, fieldIndex) => (
+            <div
+              key={`${this.props.label}-${fieldIndex}`}
+              style={{ width: '100%' }}
+              ref={(ref) => { this.refIfLastRow(ref, fieldIndex); }}
+            >
+              <Row bottom="xs">
+                <Col xs={12} sm={8}>
+                  <Row>
+                    <Col xs={10}>
+                      <Row>
+                        {this.props.template.map((t, i) => (
+                          <Col xs key={`field-${i}`}>
+                            {this.renderControl(fields, f, fieldIndex, t, i)}
+                          </Col>
+                        ))}
+                      </Row>
+                    </Col>
+                    <Col xs={2}>
+                      <Layout className={fieldIndex === 0 ? 'marginTopLabelSpacer' : ''}>
+                        <Button
+                          buttonStyle="link"
+                          style={{ padding: 0, marginBottom: '12px' }}
+                          onClick={() => { this.handleRemove(fieldIndex, f); }}
+                          title={this.props.intl.formatMessage(
+                            { id: 'stripes-components.removeFields' },
+                            { item: this.props.label, num: fieldIndex + 1 }
+                          )}
+                        >
+                          <Icon icon="trashBin" />
+                        </Button>
+                      </Layout>
+                    </Col>
+                  </Row>
+                </Col>
+                <Col xs={12} sm={4}>
+                  {fieldIndex === fields.length - 1 &&
+                    <Button
+                      fullWidth
+                      style={{ marginBottom: '12px' }}
+                      onClick={() => { this.props.onAddField(fields); }}
+                      id={this.addButtonId}
+                    >
+                      {addLabel}
+                    </Button>
+                  }
+                </Col>
+              </Row>
+            </div>
+          ))}
+        </fieldset>
+      </div>
+    );
+  }
+}
+
+FieldRow.propTypes = FieldRowPropTypes;
+
+export default injectIntl(FieldRow);

--- a/lib/RepeatableField/RepeatableField.css
+++ b/lib/RepeatableField/RepeatableField.css
@@ -1,0 +1,3 @@
+.RFLegend {
+  margin-bottom: 6px;
+}

--- a/lib/RepeatableField/RepeatableField.js
+++ b/lib/RepeatableField/RepeatableField.js
@@ -1,0 +1,94 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import cloneDeep from 'lodash/cloneDeep';
+import { FieldArray } from 'redux-form';
+import FieldRow from './FieldRow';
+
+const RepeatableFieldPropTypes = {
+  addButtonId: PropTypes.string,
+  addDefaultItem: PropTypes.bool,
+  addLabel: PropTypes.string,
+  label: PropTypes.string,
+  name: PropTypes.string.isRequired,
+  newItemTemplate: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
+  template: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.object),
+  ]),
+};
+
+const contextTypes = {
+  _reduxForm: PropTypes.object,
+};
+
+class RepeatableField extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.lastField = null;
+
+    this._added = false;
+    this._arrayId = `${this.props.label}-fields`;
+    this.buildComponentFromTemplate = this.buildComponentFromTemplate.bind(this);
+    this.addDefaultField = this.addDefaultField.bind(this);
+    this.handleAddField = this.handleAddField.bind(this);
+  }
+
+  componentDidUpdate() {
+    if (this._added && this.lastRow) {
+      const firstInput = this.lastRow.querySelector('input, select');
+      if (firstInput) {
+        firstInput.focus();
+        this._added = false;
+      }
+    }
+  }
+
+  buildComponentFromTemplate = ({ templateIndex, input, meta, ...rest }) => {
+    const Component = this.props.template[templateIndex].component;
+    return (
+      <Component input={input} meta={meta} {...rest} />
+    );
+  }
+
+  addDefaultField(fields) {
+    if (this.props.newItemTemplate) {
+      fields.push(cloneDeep(this.props.newItemTemplate));
+    } else {
+      fields.push();
+    }
+  }
+
+  handleAddField(fields) {
+    if (this.props.newItemTemplate) {
+      fields.push(cloneDeep(this.props.newItemTemplate));
+    } else {
+      fields.push();
+    }
+    this._added = true;
+  }
+
+  render() {
+    return (
+      <FieldArray
+        name={this.props.name}
+        component={FieldRow}
+        onAddField={this.handleAddField}
+        formatter={this.buildComponentFromTemplate}
+        template={this.props.template}
+        containerRef={(ref) => { this.container = ref; }}
+        label={this.props.label}
+        newItemTemplate={this.props.newItemTemplate}
+        addDefault={this.addDefaultField}
+        addDefaultItem={this.props.addDefaultItem}
+        addLabel={this.props.addLabel}
+        addButtonId={this.props.addButtonId}
+        lastRowRef={(ref) => { this.lastRow = ref; }}
+      />
+    );
+  }
+}
+
+RepeatableField.propTypes = RepeatableFieldPropTypes;
+RepeatableField.contextTypes = contextTypes;
+
+export default RepeatableField;

--- a/lib/RepeatableField/index.js
+++ b/lib/RepeatableField/index.js
@@ -1,0 +1,1 @@
+export { default } from './RepeatableField';

--- a/lib/RepeatableField/readme.md
+++ b/lib/RepeatableField/readme.md
@@ -1,0 +1,87 @@
+_Temporarily copied over from `stripes-components`, since there will be breaking changes there._
+
+# Repeatable Field
+Form component for rendering arrays of editable data.
+
+## Usage
+This example renders a list of items where multiple fields (a `<TextField>` and a `<Select>` field) are rendered for each item:
+
+```
+  <RepeatableField
+    name="things"
+    label="List of multi-field values"
+    addLabel="+ Add a multi-field item"
+    template= {[{
+        name:"name",
+        component: TextField,
+      },
+      {
+        name:"type",
+        component: Select,
+        dataOptions: [{label:"Type 1", value: "1"}, {label: "Type 2", value: "2"}, {label: "Type 3", value: "3"}],
+      },
+    ]}
+    newItemTemplate= {{name:"", type:"1"}}
+  />
+```
+
+## Props
+
+Name | type | description | default | required
+--- | --- | --- | --- | ---
+name | string | Name of particular array of data that the rendered array of fields will refer to. |  | yes
+label  | string | The visible label of the array of fields | | yes
+addLabel | string | text for the 'Add item' button that's rendered with the fields. | |
+addButtonId | string | HTML `id` attribute to assign to the add button. If not provided, one will be generated. | |
+template | array of objects | Each object within the array represents props that will be passed to the rendered redux-form `<Field>` inputs. | | yes
+newItemTemplate | object | Object representing the default field values applied when a new item is added to the array. | | yes
+addDefaultItem | bool | Sets whether or not the list will add a default, empty item. | `false` |
+
+## Single field example
+Renders a single `<TextField>` for each item...
+```
+<RepeatableField
+  name="singleFields"
+  label="List of single values"
+  addLabel="+ Add a field"
+  template= {[{
+    name:"name",
+    component: TextField,
+  }]}
+  newItemTemplate= {{name:""}}
+/>
+```
+
+## Custom Field components
+
+The `component` property of the `template` array can be used to pass in an existing component. If deeper control of props is necessary, such as option lists for `<Select>` inputs being manipulated based on `field` settings, you can pass a rendering function through to a `render` key on the template object instead of using the `component` key. The function will be passed the `fields` object, `field`, `fieldIndex`, `template`, `templateIndex` for use within your render function.
+
+```
+const renderLanguageField = ({fields, field, fieldIndex, template, templateIndex}) => {
+  const languageOptions = languages.selectOptions(field);
+  return (
+    <Field
+      label={fieldIndex === 0 ? 'language' : null}
+      name={`${field}`}
+      component={Select}
+      dataOptions={[{ label: 'Select language', value: '' }, ...languageOptions]}
+    />
+  );
+}
+
+class LanguageFields extends React.Component {
+  render() {
+    return (
+      <RepeatableField
+        name="languages"
+        label="Languages"
+        addLabel="+ Add language"
+        addId="clickable-add-language"
+        template={[{
+          render: renderLanguageField
+        }]}
+      />
+    );
+  }
+}
+```

--- a/settings/LocationLocations/DetailsField.js
+++ b/settings/LocationLocations/DetailsField.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import TextField from '@folio/stripes-components/lib/TextField';
-import RepeatableField from '@folio/stripes-components/lib/RepeatableField';
+import RepeatableField from '../../lib/RepeatableField';
 import AutoSuggest from '../../lib/AutoSuggest';
 
 class DetailsField extends React.Component {


### PR DESCRIPTION
`stripes-components` is about to have breaking changes to `RepeatableField`, so to put off migrating this use of it, I copied over the `RepeatableField` code here temporarily. I didn't attempt to copy the git history this time, since I anticipate a very short shelf life for this code.