### PR TITLE
Fix ViewMetaData import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change history for ui-organization
 
+## [2.5.1](https://github.com/folio-org/ui-organization/tree/v2.5.1) (2018-10-05)
+[Full Changelog](https://github.com/folio-org/ui-organization/compare/v2.5.0...v2.5.1)
+
+* Fix `ViewMetaData` import
+
 ## [2.5.0](https://github.com/folio-org/ui-organization/tree/v2.5.0) (2018-10-04)
 [Full Changelog](https://github.com/folio-org/ui-organization/compare/v2.3.0...v2.5.0)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/organization",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Organization settings",
   "repository": "folio-org/ui-organization",
   "publishConfig": {

--- a/settings/ServicePoints/ServicePointDetail.js
+++ b/settings/ServicePoints/ServicePointDetail.js
@@ -2,7 +2,7 @@ import { cloneDeep } from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Accordion, Col, ExpandAllButton, KeyValue, Row } from '@folio/stripes/components';
-import ViewMetaData from '@folio/stripes/smart-components';
+import { ViewMetaData } from '@folio/stripes/smart-components';
 
 import LocationList from './LocationList';
 


### PR DESCRIPTION
Fixes
```
WARNING in ./node_modules/@folio/organization/settings/ServicePoints/ServicePointDetail.js 42:48-60
"export 'default' (imported as 'ViewMetaData') was not found in '@folio/stripes/smart-components'
```
for https://issues.folio.org/browse/FOLIO-1547

Includes `v2.5.1` release.