### PR TITLE
Remove downshift and react-tether

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,11 +142,9 @@
   },
   "dependencies": {
     "@folio/react-intl-safe-html": "^1.0.1",
-    "downshift": "^2.0.19",
     "lodash": "^4.17.4",
     "prop-types": "^15.6.0",
     "react-intl": "^2.3.0",
-    "react-tether": "^1.0.1",
     "redux-form": "^7.0.3"
   },
   "peerDependencies": {


### PR DESCRIPTION
Noticed when running `yarn install` in `folio-org/platform-core` branch:
```
warning "@folio/organization > react-tether@1.0.2" has unmet peer dependency "react-dom@^0.14.0 || ^15.0.0 || ^16.0.0".
```

With `<AutoSuggest>` now in `stripes-components`, `downshift` and `react-tether` are no longer dependencies of this repo.