### PR TITLE
Move SP to Location Relationship Establishment from SP Record to Loca…

### DIFF
--- a/lib/RepeatableField/FieldRow.js
+++ b/lib/RepeatableField/FieldRow.js
@@ -40,7 +40,7 @@ class FieldRow extends React.Component {
     this.addButton = null;
     this.srstatus = null;
     this.action = null;
-
+    this.buttonEl = React.createRef();
     this.addButtonId = this.props.addButtonId || uniqueId(`${this.props.label}AddButton`);
   }
 
@@ -85,7 +85,7 @@ class FieldRow extends React.Component {
           `${label} ${contextualSpeech} has been removed. ${fields.length} ${label} total`
         );
         this.action = null;
-        if (document.getElementById(this.addButtonId)) document.getElementById(this.addButtonId).focus();
+        setTimeout(() => this.buttonEl.current.focus());
       }
     }
   }
@@ -159,6 +159,7 @@ class FieldRow extends React.Component {
                       style={{ marginBottom: '12px' }}
                       onClick={() => { this.props.onAddField(fields); }}
                       id={this.addButtonId}
+                      ref={this.buttonEl}
                     >
                       {this.props.addLabel ? this.props.addLabel : `+ Add ${this.props.label}`}
                     </Button>

--- a/lib/RepeatableField/FieldRow.js
+++ b/lib/RepeatableField/FieldRow.js
@@ -85,7 +85,7 @@ class FieldRow extends React.Component {
           `${label} ${contextualSpeech} has been removed. ${fields.length} ${label} total`
         );
         this.action = null;
-        document.getElementById(this.addButtonId).focus();
+        if (document.getElementById(this.addButtonId)) document.getElementById(this.addButtonId).focus();
       }
     }
   }
@@ -135,6 +135,7 @@ class FieldRow extends React.Component {
 
   render() {
     const { fields, intl } = this.props;
+
     let addLabel = intl.formatMessage(
       { id: 'stripes-components.addNewField' },
       { item: this.props.label }

--- a/settings/LocationLocations/LocationDetail.js
+++ b/settings/LocationLocations/LocationDetail.js
@@ -7,7 +7,9 @@ import {
   Col,
   ExpandAllButton,
   KeyValue,
-  Row
+  Row,
+  Headline,
+  List
 } from '@folio/stripes/components';
 import { ViewMetaData } from '@folio/stripes/smart-components';
 
@@ -24,6 +26,10 @@ class LocationDetail extends React.Component {
     libraries: {
       type: 'okapi',
       path: 'location-units/libraries/!{initialValues.libraryId}',
+    },
+    servicePoints: {
+      type: 'okapi',
+      path: 'service-points',
     },
   });
 
@@ -45,6 +51,9 @@ class LocationDetail extends React.Component {
 
     this.handleSectionToggle = this.handleSectionToggle.bind(this);
     this.handleExpandAll = this.handleExpandAll.bind(this);
+    this.renderServicePoints = this.renderServicePoints.bind(this);
+    this.renderServicePoint = this.renderServicePoint.bind(this);
+
     this.state = {
       sections: {
         generalInformation: true,
@@ -67,6 +76,46 @@ class LocationDetail extends React.Component {
       newState.sections = sections;
       return newState;
     });
+  }
+
+  renderServicePoint(sp, index) {
+    return (
+      index === 0 ?
+        <li key={index}>
+          {sp}
+          {' '}
+          (primary)
+        </li> :
+        <li key={index}>
+          {sp}
+        </li>
+    );
+  }
+
+  renderServicePoints() {
+    const { initialValues: loc, resources: { servicePoints } } = this.props;
+    const servicePointsMap = (servicePoints && servicePoints.hasLoaded) ? ((servicePoints || {}).records || [])[0].servicepoints.reduce((map, item) => {
+      map[item.id] = item.name;
+      return map;
+    }, {}) : {};
+
+    const itemsList = [];
+    // as primary servicePoint surely exists and its index would be at the oth position of itemsList array
+    if (servicePointsMap) itemsList.push(servicePointsMap[loc.primaryServicePoint]);
+    if (loc.servicePointIds.length !== 0) {
+      loc.servicePointIds.forEach((item) => {
+        // exclude the primary servicepoint from being added again into the array
+        if (!itemsList.includes(item.selectSP)) itemsList.push(item.selectSP);
+      });
+    }
+
+    return (
+      <List
+        items={itemsList}
+        itemFormatter={this.renderServicePoint}
+        isEmptyMessage="empty"
+      />
+    );
   }
 
   handleSectionToggle({ id }) {
@@ -153,6 +202,17 @@ class LocationDetail extends React.Component {
           <Row>
             <Col xs={12}>
               <KeyValue label={this.translate('locations.discoveryDisplayName')} value={loc.discoveryDisplayName} />
+            </Col>
+          </Row>
+          <Row>
+            <Col xs={12}>
+              <Headline size="medium" margin="medium" tag="h3">
+                {this.translate('locations.servicePoints')}
+              </Headline>
+              <div>
+                {this.renderServicePoints()}
+              </div>
+
             </Col>
           </Row>
           <Row>

--- a/settings/LocationLocations/LocationDetail.js
+++ b/settings/LocationLocations/LocationDetail.js
@@ -1,4 +1,4 @@
-import { cloneDeep, get } from 'lodash';
+import { cloneDeep, get, isEmpty } from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
 
@@ -27,10 +27,6 @@ class LocationDetail extends React.Component {
       type: 'okapi',
       path: 'location-units/libraries/!{initialValues.libraryId}',
     },
-    servicePoints: {
-      type: 'okapi',
-      path: 'service-points',
-    },
   });
 
   static propTypes = {
@@ -44,6 +40,7 @@ class LocationDetail extends React.Component {
       campuses: PropTypes.object,
       libraries: PropTypes.object,
     }).isRequired,
+    servicePointsById: PropTypes.object,
   };
 
   constructor(props) {
@@ -93,15 +90,11 @@ class LocationDetail extends React.Component {
   }
 
   renderServicePoints() {
-    const { initialValues: loc, resources: { servicePoints } } = this.props;
-    const servicePointsMap = (servicePoints && servicePoints.hasLoaded) ? ((servicePoints || {}).records || [])[0].servicepoints.reduce((map, item) => {
-      map[item.id] = item.name;
-      return map;
-    }, {}) : {};
+    const { initialValues: loc, servicePointsById } = this.props;
 
     const itemsList = [];
-    // as primary servicePoint surely exists and its index would be at the oth position of itemsList array
-    if (servicePointsMap) itemsList.push(servicePointsMap[loc.primaryServicePoint]);
+    // as primary servicePoint surely exists and its index would be at the 0th position of itemsList array
+    if (!isEmpty(servicePointsById)) itemsList.push(servicePointsById[loc.primaryServicePoint]);
     if (loc.servicePointIds.length !== 0) {
       loc.servicePointIds.forEach((item) => {
         // exclude the primary servicepoint from being added again into the array

--- a/settings/LocationLocations/LocationForm.js
+++ b/settings/LocationLocations/LocationForm.js
@@ -112,7 +112,7 @@ class LocationForm extends React.Component {
     });
 
     data.servicePointIds.forEach((item) => {
-      if (item.primary === true) servicePointsObject.primaryServicePoint = servicePointsMap[item.selectSP];
+      if (item.primary) servicePointsObject.primaryServicePoint = servicePointsMap[item.selectSP];
     });
 
     const detailsObject = {};

--- a/settings/LocationLocations/LocationForm.js
+++ b/settings/LocationLocations/LocationForm.js
@@ -25,7 +25,7 @@ import {
 import SafeHTMLMessage from '@folio/react-intl-safe-html';
 import { ViewMetaData } from '@folio/stripes/smart-components';
 import stripesForm from '@folio/stripes/form';
-
+import ServicePointsFields from './ServicePointsFields';
 import CampusField from './CampusField';
 import LibraryField from './LibraryField';
 import DetailsField from './DetailsField';
@@ -95,11 +95,26 @@ class LocationForm extends React.Component {
   }
 
   save(data) {
-    const { cloning } = this.props;
+    const { cloning, locationResources } = this.props;
     if (cloning) this.validateCloning(data);
-
     // massage the "details" property which is represented in the API as
     // an object but on the form as an array of key-value pairs
+    const servicePointsObject = {};
+
+    const servicePointsMap = ((locationResources.servicePoints || {}).records || []).reduce((map, item) => {
+      map[item.name] = item.id;
+      return map;
+    }, {});
+
+    servicePointsObject.servicePointIds = [];
+    data.servicePointIds.forEach((item) => {
+      servicePointsObject.servicePointIds.push(servicePointsMap[item.selectSP]);
+    });
+
+    data.servicePointIds.forEach((item) => {
+      if (item.primary === true) servicePointsObject.primaryServicePoint = servicePointsMap[item.selectSP];
+    });
+
     const detailsObject = {};
     if (!data.detailsArray) {
       data.detailsArray = [];
@@ -109,6 +124,8 @@ class LocationForm extends React.Component {
     });
     delete data.detailsArray;
     data.details = detailsObject;
+    data.primaryServicePoint = servicePointsObject.primaryServicePoint;
+    data.servicePointIds = servicePointsObject.servicePointIds;
 
     this.props.onSave(data);
   }
@@ -291,6 +308,11 @@ class LocationForm extends React.Component {
       institutions.push({ value: i.id, label: `${i.name} ${i.code ? `(${i.code})` : ''}` });
     });
 
+    const servicePoints = [];
+    ((locationResources.servicePoints || {}).records || []).forEach(i => {
+      servicePoints.push({ label: `${i.name}` });
+    });
+
     // massage the "details" property which is represented in the API as
     // an object but on the form as an array of key-value pairs sorted by key
     const detailsArray = [];
@@ -382,6 +404,11 @@ class LocationForm extends React.Component {
               <Row>
                 <Col xs={8}>
                   <Field label={`${this.translate('locations.discoveryDisplayName')} *`} name="discoveryDisplayName" id="input-location-discovery-display-name" component={TextField} fullWidth disabled={disabled} />
+                </Col>
+              </Row>
+              <Row>
+                <Col xs={8}>
+                  <ServicePointsFields servicePoints={servicePoints} translate={this.translate} />
                 </Col>
               </Row>
               <Row>

--- a/settings/LocationLocations/LocationForm.js
+++ b/settings/LocationLocations/LocationForm.js
@@ -52,6 +52,7 @@ class LocationForm extends React.Component {
     onCancel: PropTypes.func,
     onRemove: PropTypes.func,
     pristine: PropTypes.bool,
+    servicePointsByName: PropTypes.object,
     submitting: PropTypes.bool,
     cloning: PropTypes.bool,
     change: PropTypes.func.isRequired,
@@ -95,24 +96,16 @@ class LocationForm extends React.Component {
   }
 
   save(data) {
-    const { cloning, locationResources } = this.props;
+    const { cloning } = this.props;
     if (cloning) this.validateCloning(data);
     // massage the "details" property which is represented in the API as
     // an object but on the form as an array of key-value pairs
     const servicePointsObject = {};
 
-    const servicePointsMap = ((locationResources.servicePoints || {}).records || []).reduce((map, item) => {
-      map[item.name] = item.id;
-      return map;
-    }, {});
-
     servicePointsObject.servicePointIds = [];
     data.servicePointIds.forEach((item) => {
-      servicePointsObject.servicePointIds.push(servicePointsMap[item.selectSP]);
-    });
-
-    data.servicePointIds.forEach((item) => {
-      if (item.primary) servicePointsObject.primaryServicePoint = servicePointsMap[item.selectSP];
+      servicePointsObject.servicePointIds.push(this.props.servicePointsByName[item.selectSP]);
+      if (item.primary) servicePointsObject.primaryServicePoint = this.props.servicePointsByName[item.selectSP];
     });
 
     const detailsObject = {};

--- a/settings/LocationLocations/LocationManager.js
+++ b/settings/LocationLocations/LocationManager.js
@@ -148,19 +148,21 @@ class LocationManager extends React.Component {
       institutionId: null,
       campusId: null,
       libraryId: null,
-      servicePointsMap: {},
+      servicePointsById: {},
+      servicePointsByName: {}
     };
   }
 
   static getDerivedStateFromProps(nextProps) {
     const { resources } = nextProps;
-
+    const servicePointsByName = {};
     if (resources.servicePoints && resources.servicePoints.hasLoaded) {
-      const servicePointsMap = ((resources.servicePoints || {}).records || []).reduce((map, item) => {
+      const servicePointsById = ((resources.servicePoints || {}).records || []).reduce((map, item) => {
         map[item.id] = item.name;
+        servicePointsByName[item.name] = item.id;
         return map;
       }, {});
-      return { servicePointsMap };
+      return { servicePointsById, servicePointsByName };
     }
     return null;
   }
@@ -354,7 +356,7 @@ class LocationManager extends React.Component {
 
     const locations = cloneDeep((resources.entries || {}).records || []).map((location) => {
       location.servicePointIds = (location.servicePointIds || []).map(id => ({
-        selectSP: this.state.servicePointsMap[id],
+        selectSP: this.state.servicePointsById[id],
         primary: (location.primaryServicePoint === id),
       }));
       return location;
@@ -371,6 +373,8 @@ class LocationManager extends React.Component {
         entryList={sortBy(locations, ['name'])}
         detailComponent={this.connectedLocationDetail}
         paneTitle={this.props.label}
+        servicePointsByName={this.state.servicePointsByName}
+        servicePointsById={this.state.servicePointsById}
         entryLabel={this.translate('locations.location')}
         entryFormComponent={LocationForm}
         validate={this.validate}

--- a/settings/LocationLocations/LocationManager.js
+++ b/settings/LocationLocations/LocationManager.js
@@ -1,9 +1,8 @@
-import { sortBy } from 'lodash';
+import { sortBy, cloneDeep } from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { EntryManager } from '@folio/stripes/smart-components';
-import { Select } from '@folio/stripes/components';
-import { Button, Col, Headline, Row } from '@folio/stripes-components';
+import { Select, Button, Col, Headline, Row } from '@folio/stripes/components';
 import { FormattedMessage } from 'react-intl';
 
 import LocationDetail from './LocationDetail';
@@ -57,6 +56,12 @@ class LocationManager extends React.Component {
       records: 'loclibs',
       accumulate: true,
     },
+    servicePoints: {
+      type: 'okapi',
+      records: 'servicepoints',
+      path: 'service-points',
+      resourceShouldRefresh: true,
+    },
     holdingsEntries: {
       type: 'okapi',
       path: 'holdings-storage/holdings',
@@ -78,6 +83,9 @@ class LocationManager extends React.Component {
       entries: PropTypes.shape({
         records: PropTypes.arrayOf(PropTypes.object),
       }),
+      servicePoints: PropTypes.shape({
+        records: PropTypes.arrayOf(PropTypes.object),
+      }),
       institutions: PropTypes.shape({
         records: PropTypes.arrayOf(PropTypes.object),
       }),
@@ -90,6 +98,11 @@ class LocationManager extends React.Component {
     }).isRequired,
     mutator: PropTypes.shape({
       entries: PropTypes.shape({
+        POST: PropTypes.func,
+        PUT: PropTypes.func,
+        DELETE: PropTypes.func,
+      }),
+      servicePoints: PropTypes.shape({
         POST: PropTypes.func,
         PUT: PropTypes.func,
         DELETE: PropTypes.func,
@@ -135,7 +148,21 @@ class LocationManager extends React.Component {
       institutionId: null,
       campusId: null,
       libraryId: null,
+      servicePointsMap: {},
     };
+  }
+
+  static getDerivedStateFromProps(nextProps) {
+    const { resources } = nextProps;
+
+    if (resources.servicePoints && resources.servicePoints.hasLoaded) {
+      const servicePointsMap = ((resources.servicePoints || {}).records || []).reduce((map, item) => {
+        map[item.id] = item.name;
+        return map;
+      }, {});
+      return { servicePointsMap };
+    }
+    return null;
   }
 
   /**
@@ -188,6 +215,20 @@ class LocationManager extends React.Component {
 
       if (detailsErrors.length) {
         errors.detailsArray = detailsErrors;
+      }
+    }
+
+    const servicePointErrors = [];
+    if (values.servicePointIds) {
+      values.servicePointIds.forEach((entry, i) => {
+        const servicePointError = {};
+        if (!entry || !entry.selectSP) {
+          servicePointError.selectSP = this.props.stripes.intl.formatMessage({ id: 'stripes-core.label.missingRequiredField' });
+          servicePointErrors[i] = servicePointError;
+        }
+      });
+      if (servicePointErrors.length) {
+        errors.servicePointIds = servicePointErrors;
       }
     }
 
@@ -309,16 +350,25 @@ class LocationManager extends React.Component {
 
   render() {
     const { institutionId, campusId, libraryId } = this.state;
+    const { resources } = this.props;
+
+    const locations = cloneDeep((resources.entries || {}).records || []).map((location) => {
+      location.servicePointIds = (location.servicePointIds || []).map(id => ({
+        selectSP: this.state.servicePointsMap[id],
+        primary: (location.primaryServicePoint === id),
+      }));
+      return location;
+    });
 
     return (
       <EntryManager
         stripes={this.props.stripes}
-        defaultEntry={{ isActive: true, institutionId, campusId, libraryId }}
+        defaultEntry={{ isActive: true, institutionId, campusId, libraryId, servicePointIds: [{ selectSP: '', primary: true }] }}
         clonable
         addMenu={(<div />)}
         parentMutator={this.props.mutator}
         locationResources={this.props.resources}
-        entryList={sortBy((this.props.resources.entries || {}).records || [], ['name'])}
+        entryList={sortBy(locations, ['name'])}
         detailComponent={this.connectedLocationDetail}
         paneTitle={this.props.label}
         entryLabel={this.translate('locations.location')}

--- a/settings/LocationLocations/ServicePointsFields.css
+++ b/settings/LocationLocations/ServicePointsFields.css
@@ -1,0 +1,25 @@
+.primaryToggle {
+  padding: 4px 8px;
+  color: #555;
+  font-size: 12px;
+  cursor: pointer;
+  margin-bottom: 0;
+
+  & input[type="radio"] {
+    margin: 0 4px;
+    vertical-align: text-top;
+  }
+}
+
+.label {
+  font-size: var(--font-size-small);
+  line-height: var(--line-height);
+  margin-bottom: 0.25rem;
+  color: var(--color-text);
+
+  &.required::after {
+    content: '(required)';
+    margin: 0 4px;
+    color: #666;
+  }
+}

--- a/settings/LocationLocations/ServicePointsFields.js
+++ b/settings/LocationLocations/ServicePointsFields.js
@@ -1,0 +1,117 @@
+import React from 'react';
+import { Field, FieldArray } from 'redux-form';
+import PropTypes from 'prop-types';
+import findIndex from 'lodash/findIndex';
+import cloneDeep from 'lodash/cloneDeep';
+import { Select, RadioButton, RepeatableField, Layout, Row, Col } from '@folio/stripes/components';
+import css from './ServicePointsFields.css';
+
+const omitUsedOptions = (list, usedValues, key, id) => {
+  const unUsedValues = cloneDeep(list);
+  if (usedValues) {
+    usedValues.forEach((item, index) => {
+      if (id !== index) {
+        const usedValueIndex = findIndex(unUsedValues, v => {
+          return v.label === item[key];
+        });
+        if (usedValueIndex !== -1) {
+          unUsedValues.splice(usedValueIndex, 1);
+        }
+      }
+    });
+  }
+  return unUsedValues;
+};
+
+class ServicePointsFields extends React.Component {
+  static propTypes = {
+    servicePoints: PropTypes.arrayOf(PropTypes.object),
+    translate: PropTypes.func,
+  };
+
+  static contextTypes = {
+    _reduxForm: PropTypes.object,
+  }
+
+  constructor(props) {
+    super(props);
+    this.singlePrimary = this.singlePrimary.bind(this);
+    this.renderFields = this.renderFields.bind(this);
+    this.radioButtonComp = this.radioButtonComp.bind(this);
+  }
+
+  singlePrimary(id) {
+    const { values, dispatch, change } = this.context._reduxForm;
+    values.servicePointIds.forEach((a, i) => {
+      if (i === id) {
+        dispatch(change(`servicePointIds[${i}].primary`, true));
+      } else {
+        dispatch(change(`servicePointIds[${i}].primary`, false));
+      }
+    });
+  }
+
+  radioButtonComp({ input, ...props }) {
+    return (
+      <RadioButton
+        onChange={() => { this.singlePrimary(props.fieldIndex); }}
+        checked={input.value}
+        name={input.name}
+        aria-label={`servicePoint use as primary ${props.fieldIndex}`}
+      />
+    );
+  }
+
+  renderFields(field, index) {
+    const { values } = this.context._reduxForm;
+    const list = omitUsedOptions(this.props.servicePoints, values.servicePointIds, 'selectSP', index);
+    const options = [{ label: 'Select service point', value: '' }, ...list];
+    return (
+      <Row key={index} style={{ marginBottom:'-30px' }}>
+        <Layout style={{ marginLeft:'8px', width:'180px' }} className="marginTopLabelSpacer">
+          <Field
+            component={Select}
+            name={`${field}.selectSP`}
+            dataOptions={options}
+          />
+        </Layout>
+        <Layout style={{ marginLeft:'15px', marginRight:'40px' }} className="marginTopLabelSpacer">
+          <Field
+            component={this.radioButtonComp}
+            fieldIndex={index}
+            name={`${field}.primary`}
+          />
+        </Layout>
+      </Row>
+    );
+  }
+
+  render() {
+    const { values } = this.context._reduxForm;
+
+    const marginBottom = (values.servicePointIds && values.servicePointIds.length) === 0 ? '34px' : '0px';
+    return (
+      <React.Fragment>
+        <Layout style={{ marginBottom }}>
+          <Row className={css.label} style={{ marginBottom:'-35px' }}>
+            <Col xs={3}>
+              {`${this.props.translate('locations.servicePoints')} *`}
+            </Col>
+            <Col xs={2} style={{ marginLeft:'-35px' }}>
+              {`${this.props.translate('locations.primary')}`}
+            </Col>
+          </Row>
+        </Layout>
+        <FieldArray
+          addLabel="+ Add service point"
+          rerenderOnEveryChange
+          component={RepeatableField}
+          name="servicePointIds"
+          renderField={this.renderFields}
+        />
+      </React.Fragment>
+    );
+  }
+}
+
+export default ServicePointsFields;

--- a/settings/ServicePoints/ServicePointDetail.js
+++ b/settings/ServicePoints/ServicePointDetail.js
@@ -100,13 +100,6 @@ class ServicePointDetail extends React.Component {
             </Col>
           </Row>
         </Accordion>
-
-        <this.cLocationList
-          locationIds={servicePoint.locationIds}
-          expanded={sections.locationSection}
-          stripes={this.props.stripes}
-          onToggle={this.handleSectionToggle}
-        />
       </div>
     );
   }

--- a/settings/ServicePoints/ServicePointForm.js
+++ b/settings/ServicePoints/ServicePointForm.js
@@ -38,7 +38,6 @@ class ServicePointForm extends React.Component {
     handleSubmit: PropTypes.func.isRequired,
     onSave: PropTypes.func,
     onCancel: PropTypes.func,
-    change: PropTypes.func,
     onRemove: PropTypes.func,
     pristine: PropTypes.bool,
     submitting: PropTypes.bool,
@@ -182,7 +181,7 @@ class ServicePointForm extends React.Component {
   }
 
   render() {
-    const { stripes, handleSubmit, initialValues, change } = this.props;
+    const { stripes, handleSubmit, initialValues } = this.props;
     const servicePoint = initialValues || {};
     const { confirmDelete, sections } = this.state;
     const disabled = !stripes.hasPerm('settings.organization.enabled');
@@ -245,15 +244,6 @@ class ServicePointForm extends React.Component {
                 </Col>
               </Row>
             </Accordion>
-
-            <this.cLocationList
-              initialValues={servicePoint}
-              expanded={sections.locationSection}
-              change={change}
-              stripes={stripes}
-              onToggle={this.handleSectionToggle}
-            />
-
             <ConfirmationModal
               id="deleteservicepoint-confirmation"
               open={confirmDelete}

--- a/translations/ui-organization/en.json
+++ b/translations/ui-organization/en.json
@@ -50,6 +50,8 @@
   "settings.location.locations.generalInformation": "General information",
   "settings.location.locations.name": "FOLIO name",
   "settings.location.locations.discoveryDisplayName": "Discovery display name",
+  "settings.location.locations.servicePoints": "Service point(s)",
+  "settings.location.locations.primary": "Primary",
   "settings.location.locations.status": "Status",
   "settings.location.locations.active": "Active",
   "settings.location.locations.inactive": "Inactive",


### PR DESCRIPTION
…tion Record, refs UIORG-115

- Removed the assigned locations section on ServicePoints detail and forms
- New service point required field added to the locations form
- Display SP list with the primary one on the SP detail form
- Added Service point select component accompanied by a radio button indicating primary SP or not
- Should require atleast one primary service point selected
- Added logic to display only the unused service points in the subsequent dropdowns to prevent same SP from being selected
- Used repeatable field for rendering the rows. Clicking the trash icon should delete the field row
- Added validation to fill in the service point dropdown if left empty

Cases yet to handle:

1) Prevent the last field row from being deleted.
2) Make the primary radio button to set to true when only one SP is displayed.