### PR TITLE
Align mod-inventory-storage dependency versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add ability to copy location record. Fixes UIORG-117.
 * Enable filtering of location records by institution, campus and library. Fixes UIORG-92.
 * Show correct Pickup Location flag. Fixes UIORG-118.
+* Service point array is now a required attribute of locations. Refs UIORG-115.
 
 ## [2.5.1](https://github.com/folio-org/ui-organization/tree/v2.5.1) (2018-10-05)
 [Full Changelog](https://github.com/folio-org/ui-organization/compare/v2.5.0...v2.5.1)

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
       "location-units": "1.1",
       "locations": "3.0",
       "login-saml": "1.0",
-      "service-points": "2.0"
+      "service-points": "3.0"
     },
     "permissionSets": [
       {


### PR DESCRIPTION
An array of service-points is now a required attribute of a location.
This change aligns the `service-points` API version with that for
`locations` which had been updated in #144.

Refs [UIORG-115](https://issues.folio.org/browse/UIORG-115), [MODINVSTOR-177](https://issues.folio.org/browse/MODINVSTOR-177)