### PR TITLE
Refactor detailsArray out of location form. Part of UIORG-117

### DIFF
--- a/settings/LocationLocations/LocationForm.js
+++ b/settings/LocationLocations/LocationForm.js
@@ -288,7 +288,7 @@ class LocationForm extends React.Component {
 
   render() {
     const { stripes, handleSubmit, initialValues, locationResources } = this.props;
-    const loc = cloneDeep(initialValues || {});
+    const loc = initialValues || {};
     const { confirmDelete, sections } = this.state;
     const disabled = !stripes.hasPerm('settings.organization.enabled');
     const name = loc.name || this.translate('locations.untitledLocation');
@@ -308,14 +308,6 @@ class LocationForm extends React.Component {
     entryList.forEach(i => {
       servicePoints.push({ label: `${i.name}` });
     });
-
-    // massage the "details" property which is represented in the API as
-    // an object but on the form as an array of key-value pairs sorted by key
-    const detailsArray = [];
-    Object.keys(loc.details || []).sort().forEach(key => {
-      detailsArray.push({ name: key, value: loc.details[key] });
-    });
-    loc.detailsArray = detailsArray;
 
     return (
       <form id="form-service-point" onSubmit={handleSubmit(this.save)}>

--- a/settings/LocationLocations/LocationManager.js
+++ b/settings/LocationLocations/LocationManager.js
@@ -355,6 +355,16 @@ class LocationManager extends React.Component {
     );
   }
 
+  parseInitialValues(loc) {
+    if (!loc) return loc;
+
+    loc.detailsArray = Object.keys(loc.details || []).map(name => {
+      return { name, value: loc.details[name] };
+    }).sort();
+
+    return loc;
+  }
+
   render() {
     const { institutionId, campusId, libraryId } = this.state;
     const { resources } = this.props;
@@ -380,6 +390,7 @@ class LocationManager extends React.Component {
         paneTitle={this.props.label}
         servicePointsByName={this.state.servicePointsByName}
         servicePointsById={this.state.servicePointsById}
+        parseInitialValues={this.parseInitialValues}
         entryLabel={this.translate('locations.location')}
         entryFormComponent={LocationForm}
         validate={this.validate}


### PR DESCRIPTION
redux-form doesn't like when we mutate the `initialValues` object inside the form. This caused infinite rendering loop when we set `enableReinitialize` to  `true`  previously. It was also causing issues with record duplication in UIORG-117. 

This PR moves it out of the location form and uses  `parseInitialValues` to do the massaging right before the form is initialized.
