### PR TITLE
provide sortby key to ControlledVocab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Enable filtering of location records by institution, campus and library. Fixes UIORG-92.
 * Show correct Pickup Location flag. Fixes UIORG-118.
 * Service point array is now a required attribute of locations. Refs UIORG-115.
+* Provide sortby key to `ControlledVocab`. Refs STSMACOM-139.
 
 ## [2.5.1](https://github.com/folio-org/ui-organization/tree/v2.5.1) (2018-10-05)
 [Full Changelog](https://github.com/folio-org/ui-organization/compare/v2.5.0...v2.5.1)

--- a/settings/LocationCampuses.js
+++ b/settings/LocationCampuses.js
@@ -120,7 +120,7 @@ class LocationCampuses extends React.Component {
         preCreateHook={(item) => Object.assign({}, item, { institutionId: this.state.institutionId })}
         listSuppressor={() => !this.state.institutionId}
         listSuppressorText={this.props.stripes.intl.formatMessage({ id: 'ui-organization.settings.location.campuses.missingSelection' })}
-
+        sortby="name"
       />
     );
   }

--- a/settings/LocationInstitutions.js
+++ b/settings/LocationInstitutions.js
@@ -76,6 +76,7 @@ class LocationInstitutions extends React.Component {
         formatter={formatter}
         nameKey="name"
         id="institutions"
+        sortby="name"
       />
     );
   }

--- a/settings/LocationLibraries.js
+++ b/settings/LocationLibraries.js
@@ -156,6 +156,7 @@ class LocationLibraries extends React.Component {
         preCreateHook={(item) => Object.assign({}, item, { campusId: this.state.campusId })}
         listSuppressor={() => !(this.state.institutionId && this.state.campusId)}
         listSuppressorText={this.props.stripes.intl.formatMessage({ id: 'ui-organization.settings.location.libraries.missingSelection' })}
+        sortby="name"
       />
     );
   }


### PR DESCRIPTION
`<ControlledVocab>` should have a `defaultProps` value for `sortby`, but
that value isn't being pushed down correctly so we're providing our own
prop here.

Refs [STSMACOM-139](https://issues.folio.org/browse/STSMACOM-139)