### PR TITLE
don't check users version in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Show correct Pickup Location flag. Fixes UIORG-118.
 * Service point array is now a required attribute of locations. Refs UIORG-115.
 * Provide sortby key to `ControlledVocab`. Refs STSMACOM-139.
+* Don't check users version in tests. Fixes UIORG-121.
 
 ## [2.5.1](https://github.com/folio-org/ui-organization/tree/v2.5.1) (2018-10-05)
 [Full Changelog](https://github.com/folio-org/ui-organization/compare/v2.5.0...v2.5.1)

--- a/test/ui-testing/locations.js
+++ b/test/ui-testing/locations.js
@@ -33,11 +33,6 @@ module.exports.test = function locationTest(uiTestCtx) {
 
       // @@const deletePath = `div[title="${gid}"] ~ div:last-of-type button[id*="delete"]`;
 
-      it('should open app and find version tag', (done) => {
-        nightmare
-          .use(openApp(nightmare, config, done, 'users', testVersion))
-          .then(result => result);
-      });
       it(`should create an institution "${institutionName}"`, (done) => {
         nightmare
           .click(config.select.settings)


### PR DESCRIPTION
This app used to check the ui-users version in its integration tests. I
don't know why it did that. I do know that wrecked tests that tried to
run with _only_ ui-organization installed.

Fixes [UIORG-121](https://issues.folio.org/browse/UIORG-121)