### PR TITLE
provide strings to `<option>` elements

### DIFF
--- a/src/settings/LocationCampuses.js
+++ b/src/settings/LocationCampuses.js
@@ -95,19 +95,19 @@ class LocationCampuses extends React.Component {
     }
 
     const rowFilter = (
-      <FormattedMessage id="ui-organization.settings.location.institutions.selectInstitution">
-        {selectText => (
-          <Select
-            label={<FormattedMessage id="ui-organization.settings.location.institutions.institution" />}
-            id="institutionSelect"
-            name="institutionSelect"
-            onChange={this.onChangeInstitution}
-          >
+      <Select
+        label={<FormattedMessage id="ui-organization.settings.location.institutions.institution" />}
+        id="institutionSelect"
+        name="institutionSelect"
+        onChange={this.onChangeInstitution}
+      >
+        <FormattedMessage id="ui-organization.settings.location.institutions.selectInstitution">
+          {selectText => (
             <option>{selectText}</option>
-            {institutions}
-          </Select>
-        )}
-      </FormattedMessage>
+          )}
+        </FormattedMessage>
+        {institutions}
+      </Select>
     );
 
     return (

--- a/src/settings/LocationCampuses.js
+++ b/src/settings/LocationCampuses.js
@@ -82,12 +82,33 @@ class LocationCampuses extends React.Component {
   render() {
     const institutions = [];
     (((this.props.resources.institutions || {}).records || []).forEach(i => {
-      institutions.push({ value: i.id, label: `${i.name}${i.code ? ` (${i.code})` : ''}` });
+      institutions.push(
+        <option value={i.id} key={i.id}>
+          {i.name}
+          {i.code ? ` (${i.code})` : ''}
+        </option>
+      );
     }));
 
     if (!institutions.length) {
       return <div />;
     }
+
+    const rowFilter = (
+      <FormattedMessage id="ui-organization.settings.location.institutions.selectInstitution">
+        {selectText => (
+          <Select
+            label={<FormattedMessage id="ui-organization.settings.location.institutions.institution" />}
+            id="institutionSelect"
+            name="institutionSelect"
+            onChange={this.onChangeInstitution}
+          >
+            <option>{selectText}</option>
+            {institutions}
+          </Select>
+        )}
+      </FormattedMessage>
+    );
 
     return (
       <this.connectedControlledVocab
@@ -97,16 +118,7 @@ class LocationCampuses extends React.Component {
         dataKey={undefined}
         baseUrl="location-units/campuses"
         records="loccamps"
-        rowFilter={<Select
-          label={<FormattedMessage id="ui-organization.settings.location.institutions.institution" />}
-          id="institutionSelect"
-          name="institutionSelect"
-          dataOptions={[
-            { label: <FormattedMessage id="ui-organization.settings.location.institutions.selectInstitution" />, value: '' },
-            ...institutions
-          ]}
-          onChange={this.onChangeInstitution}
-        />}
+        rowFilter={rowFilter}
         rowFilterFunction={(row) => row.institutionId === this.state.institutionId}
         label={<FormattedMessage id="ui-organization.settings.location.campuses" />}
         labelSingular={<FormattedMessage id="ui-organization.settings.location.campuses.campus" />}

--- a/src/settings/LocationLibraries.js
+++ b/src/settings/LocationLibraries.js
@@ -120,36 +120,36 @@ class LocationLibraries extends React.Component {
     };
 
     const filterBlock = (
-      <div>
-        <FormattedMessage id="ui-organization.settings.location.institutions.selectInstitution">
-          {selectText => (
-            <Select
-              label={<FormattedMessage id="ui-organization.settings.location.institutions.institution" />}
-              id="institutionSelect"
-              name="institutionSelect"
-              onChange={this.onChangeInstitution}
-            >
-              <option>{selectText}</option>
-              {institutions}
-            </Select>
-          )}
-        </FormattedMessage>
-        {this.state.institutionId &&
-          <FormattedMessage id="ui-organization.settings.location.campuses.selectCampus">
+      <React.Fragment>
+        <Select
+          label={<FormattedMessage id="ui-organization.settings.location.institutions.institution" />}
+          id="institutionSelect"
+          name="institutionSelect"
+          onChange={this.onChangeInstitution}
+        >
+          <FormattedMessage id="ui-organization.settings.location.institutions.selectInstitution">
             {selectText => (
-              <Select
-                label={<FormattedMessage id="ui-organization.settings.location.campuses.campus" />}
-                id="campusSelect"
-                name="campusSelect"
-                onChange={this.onChangeCampus}
-              >
-                <option>{selectText}</option>
-                {campuses}
-              </Select>
+              <option>{selectText}</option>
             )}
           </FormattedMessage>
+          {institutions}
+        </Select>
+        {this.state.institutionId &&
+          <Select
+            label={<FormattedMessage id="ui-organization.settings.location.campuses.campus" />}
+            id="campusSelect"
+            name="campusSelect"
+            onChange={this.onChangeCampus}
+          >
+            <FormattedMessage id="ui-organization.settings.location.campuses.selectCampus">
+              {selectText => (
+                <option>{selectText}</option>
+              )}
+            </FormattedMessage>
+            {campuses}
+          </Select>
         }
-      </div>
+      </React.Fragment>
     );
 
     return (

--- a/src/settings/LocationLibraries.js
+++ b/src/settings/LocationLibraries.js
@@ -93,7 +93,12 @@ class LocationLibraries extends React.Component {
   render() {
     const institutions = [];
     (((this.props.resources.institutions || {}).records || []).forEach(i => {
-      institutions.push({ value: i.id, label: `${i.name}${i.code ? ` (${i.code})` : ''}` });
+      institutions.push(
+        <option value={i.id} key={i.id}>
+          {i.name}
+          {i.code ? ` (${i.code})` : ''}
+        </option>
+      );
     }));
 
     if (!institutions.length) {
@@ -101,11 +106,14 @@ class LocationLibraries extends React.Component {
     }
 
     const campuses = [];
-    ((this.props.resources.campuses || {}).records || []).forEach(i => {
-      if (i.institutionId === this.state.institutionId) {
-        campuses.push({ value: i.id, label: `${i.name}${i.code ? ` (${i.code})` : ''}` });
-      }
-    });
+    (((this.props.resources.campuses || {}).records || []).forEach(i => {
+      campuses.push(
+        <option value={i.id} key={i.id}>
+          {i.name}
+          {i.code ? ` (${i.code})` : ''}
+        </option>
+      );
+    }));
 
     const formatter = {
       numberOfObjects: this.numberOfObjectsFormatter,
@@ -113,26 +121,34 @@ class LocationLibraries extends React.Component {
 
     const filterBlock = (
       <div>
-        <Select
-          label={<FormattedMessage id="ui-organization.settings.location.institutions.institution" />}
-          id="institutionSelect"
-          name="institutionSelect"
-          dataOptions={[
-            { label: <FormattedMessage id="ui-organization.settings.location.institutions.selectInstitution" />, value: '' },
-            ...institutions
-          ]}
-          onChange={this.onChangeInstitution}
-        />
-        {this.state.institutionId && <Select
-          label={<FormattedMessage id="ui-organization.settings.location.campuses.campus" />}
-          id="campusSelect"
-          name="campusSelect"
-          dataOptions={[
-            { label: <FormattedMessage id="ui-organization.settings.location.campuses.selectCampus" />, value: '' },
-            ...campuses
-          ]}
-          onChange={this.onChangeCampus}
-        />}
+        <FormattedMessage id="ui-organization.settings.location.institutions.selectInstitution">
+          {selectText => (
+            <Select
+              label={<FormattedMessage id="ui-organization.settings.location.institutions.institution" />}
+              id="institutionSelect"
+              name="institutionSelect"
+              onChange={this.onChangeInstitution}
+            >
+              <option>{selectText}</option>
+              {institutions}
+            </Select>
+          )}
+        </FormattedMessage>
+        {this.state.institutionId &&
+          <FormattedMessage id="ui-organization.settings.location.campuses.selectCampus">
+            {selectText => (
+              <Select
+                label={<FormattedMessage id="ui-organization.settings.location.campuses.campus" />}
+                id="campusSelect"
+                name="campusSelect"
+                onChange={this.onChangeCampus}
+              >
+                <option>{selectText}</option>
+                {campuses}
+              </Select>
+            )}
+          </FormattedMessage>
+        }
       </div>
     );
 

--- a/src/settings/LocationLocations/LocationForm.js
+++ b/src/settings/LocationLocations/LocationForm.js
@@ -286,7 +286,7 @@ class LocationForm extends React.Component {
 
 
   render() {
-    const { stripes, handleSubmit, initialValues, locationResources } = this.props;
+    const { stripes, handleSubmit, initialValues, locationResources, intl: { formatMessage } } = this.props;
     const loc = initialValues || {};
     const { confirmDelete, sections } = this.state;
     const disabled = !stripes.hasPerm('settings.organization.enabled');
@@ -342,7 +342,7 @@ class LocationForm extends React.Component {
                     required
                     disabled={disabled}
                     dataOptions={[
-                      { label: <FormattedMessage id="ui-organization.settings.location.institutions.selectInstitution" /> },
+                      { label: formatMessage({ id: 'ui-organization.settings.location.institutions.selectInstitution' }) },
                       ...institutions
                     ]}
                     onChange={this.handleChangeInstitution}
@@ -355,7 +355,7 @@ class LocationForm extends React.Component {
                     list={(locationResources.campuses || {}).records || []}
                     filterFieldId="institutionId"
                     formatter={(i) => `${i.name}${i.code ? ` (${i.code})` : ''}`}
-                    initialOption={{ label: <FormattedMessage id="ui-organization.settings.location.campuses.selectCampus" /> }}
+                    initialOption={{ label: formatMessage({ id: 'ui-organization.settings.location.campuses.selectCampus' }) }}
                     label={
                       <Fragment>
                         <FormattedMessage id="ui-organization.settings.location.campuses.campus" />
@@ -377,7 +377,7 @@ class LocationForm extends React.Component {
                     list={(locationResources.libraries || {}).records || []}
                     filterFieldId="campusId"
                     formatter={(i) => `${i.name}${i.code ? ` (${i.code})` : ''}`}
-                    initialOption={{ label: <FormattedMessage id="ui-organization.settings.location.libraries.selectLibrary" /> }}
+                    initialOption={{ label: formatMessage({ id: 'ui-organization.settings.location.libraries.selectLibrary' }) }}
                     label={
                       <Fragment>
                         <FormattedMessage id="ui-organization.settings.location.libraries.library" />


### PR DESCRIPTION
An `<option>`'s `text` attribute must be a string, not an object, which
means we can't pass a `<FormattedMessage>` object.