### PR TITLE
pass strings, not nodes, to ControlledVocab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Display locations associated with the service point. Fixes UIORG-127.
 * Disallow deletion of SPs that are primary for location. Fixes UIORG-129.
 * Hide service point delete button. Fixes UIORG-130.
+* Pass strings not nodes to `<ControlledVocab>`. Fixes UIORG-134.
 
 ## [2.5.1](https://github.com/folio-org/ui-organization/tree/v2.5.1) (2018-10-05)
 [Full Changelog](https://github.com/folio-org/ui-organization/compare/v2.5.0...v2.5.1)

--- a/src/settings/LocationCampuses.js
+++ b/src/settings/LocationCampuses.js
@@ -1,6 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage } from 'react-intl';
+import {
+  FormattedMessage,
+  injectIntl,
+  intlShape,
+} from 'react-intl';
 import { ControlledVocab } from '@folio/stripes/smart-components';
 import { Select } from '@folio/stripes/components';
 
@@ -32,6 +36,7 @@ class LocationCampuses extends React.Component {
         records: PropTypes.arrayOf(PropTypes.object),
       }),
     }),
+    intl: intlShape.isRequired,
     mutator: PropTypes.shape({
       institutions: PropTypes.shape({
         GET: PropTypes.func.isRequired,
@@ -120,8 +125,8 @@ class LocationCampuses extends React.Component {
         records="loccamps"
         rowFilter={rowFilter}
         rowFilterFunction={(row) => row.institutionId === this.state.institutionId}
-        label={<FormattedMessage id="ui-organization.settings.location.campuses" />}
-        labelSingular={<FormattedMessage id="ui-organization.settings.location.campuses.campus" />}
+        label={this.props.intl.formatMessage({ id: 'ui-organization.settings.location.campuses' })}
+        labelSingular={this.props.intl.formatMessage({ id: 'ui-organization.settings.location.campuses.campus' })}
         objectLabel={<FormattedMessage id="ui-organization.settings.location.locations" />}
         visibleFields={['name', 'code']}
         columnMapping={{
@@ -140,4 +145,4 @@ class LocationCampuses extends React.Component {
   }
 }
 
-export default LocationCampuses;
+export default injectIntl(LocationCampuses);

--- a/src/settings/LocationInstitutions.js
+++ b/src/settings/LocationInstitutions.js
@@ -1,6 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage } from 'react-intl';
+import {
+  FormattedMessage,
+  injectIntl,
+  intlShape,
+} from 'react-intl';
+
 import { ControlledVocab } from '@folio/stripes/smart-components';
 
 class LocationInstitutions extends React.Component {
@@ -14,6 +19,7 @@ class LocationInstitutions extends React.Component {
   });
 
   static propTypes = {
+    intl: intlShape.isRequired,
     stripes: PropTypes.shape({
       connect: PropTypes.func.isRequired,
     }).isRequired,
@@ -65,8 +71,8 @@ class LocationInstitutions extends React.Component {
         dataKey={undefined}
         baseUrl="location-units/institutions"
         records="locinsts"
-        label={<FormattedMessage id="ui-organization.settings.location.institutions" />}
-        labelSingular={<FormattedMessage id="ui-organization.settings.location.institutions.institution" />}
+        label={this.props.intl.formatMessage({ id: 'ui-organization.settings.location.institutions' })}
+        labelSingular={this.props.intl.formatMessage({ id: 'ui-organization.settings.location.institutions.institution' })}
         objectLabel={<FormattedMessage id="ui-organization.settings.location.locations" />}
         visibleFields={['name', 'code']}
         columnMapping={{
@@ -82,4 +88,4 @@ class LocationInstitutions extends React.Component {
   }
 }
 
-export default LocationInstitutions;
+export default injectIntl(LocationInstitutions);

--- a/src/settings/LocationLibraries.js
+++ b/src/settings/LocationLibraries.js
@@ -1,8 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {
+  FormattedMessage,
+  injectIntl,
+  intlShape,
+} from 'react-intl';
 import { ControlledVocab } from '@folio/stripes/smart-components';
 import { Select } from '@folio/stripes/components';
-import { FormattedMessage } from 'react-intl';
+
 
 class LocationLibraries extends React.Component {
   static manifest = Object.freeze({
@@ -27,6 +32,7 @@ class LocationLibraries extends React.Component {
   });
 
   static propTypes = {
+    intl: intlShape.isRequired,
     stripes: PropTypes.shape({
       connect: PropTypes.func.isRequired,
     }).isRequired,
@@ -162,8 +168,8 @@ class LocationLibraries extends React.Component {
         records="loclibs"
         rowFilter={filterBlock}
         rowFilterFunction={(row) => row.campusId === this.state.campusId}
-        label={<FormattedMessage id="ui-organization.settings.location.libraries" />}
-        labelSingular={<FormattedMessage id="ui-organization.settings.location.libraries.library" />}
+        label={this.props.intl.formatMessage({ id: 'ui-organization.settings.location.libraries' })}
+        labelSingular={this.props.intl.formatMessage({ id: 'ui-organization.settings.location.libraries.library' })}
         objectLabel={<FormattedMessage id="ui-organization.settings.location.locations" />}
         visibleFields={['name', 'code']}
         columnMapping={{
@@ -182,4 +188,4 @@ class LocationLibraries extends React.Component {
   }
 }
 
-export default LocationLibraries;
+export default injectIntl(LocationLibraries);

--- a/src/settings/LocationLocations/LocationManager.js
+++ b/src/settings/LocationLocations/LocationManager.js
@@ -385,7 +385,7 @@ class LocationManager extends React.Component {
         servicePointsByName={this.state.servicePointsByName}
         servicePointsById={this.state.servicePointsById}
         parseInitialValues={this.parseInitialValues}
-        entryLabel={<FormattedMessage id="ui-organization.settings.location.locations.location" />}
+        entryLabel={this.props.intl.formatMessage({ id: 'ui-organization.settings.location.locations.location' })}
         entryFormComponent={LocationForm}
         validate={this.validate}
         asyncValidate={this.asyncValidate}


### PR DESCRIPTION
`<ControlledVocab>` needs to receive strings for some props in order to
avoid displaying `[object Object]` instead of, e.g. `Institution`,
`Campus`, etc in dialog boxes and toast alerts.

Fixes [UIORG-134](https://issues.folio.org/browse/UIORG-134)