### PR TITLE
wait longer before attempting delete

### DIFF
--- a/test/ui-testing/locations.js
+++ b/test/ui-testing/locations.js
@@ -228,7 +228,7 @@ module.exports.test = function locationTest(uiTestCtx) {
           .wait('a[href="/settings/organization/location-institutions"]')
           .click('a[href="/settings/organization/location-institutions"]')
           .wait('#editList-institutions:not([data-total-count="0"])')
-          .wait(1000)
+          .wait(3000) // 3 seconds? 3 SECONDS?
           .evaluate(trashCounter, institutionName, 'institutions')
           .then((n) => {
             nightmare


### PR DESCRIPTION
Logging during testing shows that if the script immediately starts
looping through the list of institutions after they load, it gets a list
that contains some institutions and some libraries. This makes no sense
whatsoever, and does not reflect what is displayed in the UI, and yet
that's what it reports on the console. If we wait, the UI and console
appear to be in sync.

I give up. I don't want to wait. I don't understand why we're out of
sync, or even _how_ we can be out of sync in this manner. Maybe if we
had the wrong list entirely, i.e. a list of all libraries, that would
make sense. But a list of half libraries and half institutions? I got
nothin' to explain that.