### PR TITLE
Add hold shelf expiry period to service point. Fixes UIORG-143

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "@folio/eslint-config-stripes": "^3.2.1",
     "@folio/stripes": "^2.0.0",
     "@folio/stripes-cli": "^1.7.0",
-    "@folio/stripes-core": "^2.17.0",
+    "@folio/stripes-core": "^3.0.1",
     "babel-polyfill": "^6.26.0",
     "babel-eslint": "^9.0.0",
     "chai": "^4.2.0",

--- a/src/settings/ServicePoints/ServicePointForm.js
+++ b/src/settings/ServicePoints/ServicePointForm.js
@@ -287,15 +287,16 @@ class ServicePointForm extends React.Component {
               </Row>
               {
                 formValues.pickupLocation &&
-                <Period
-                  data-test-holdshelfexpiry
-                  fieldLabel="ui-organization.settings.servicePoint.expirationPeriod"
-                  selectPlaceholder="ui-organization.settings.servicePoint.selectInterval"
-                  inputValuePath="holdShelfExpiryPeriod.duration"
-                  selectValuePath="holdShelfExpiryPeriod.intervalId"
-                  entity={formValues}
-                  intervalPeriods={periods}
-                />
+                <div data-test-holdshelfexpiry>
+                  <Period
+                    fieldLabel="ui-organization.settings.servicePoint.expirationPeriod"
+                    selectPlaceholder="ui-organization.settings.servicePoint.selectInterval"
+                    inputValuePath="holdShelfExpiryPeriod.duration"
+                    selectValuePath="holdShelfExpiryPeriod.intervalId"
+                    entity={formValues}
+                    intervalPeriods={periods}
+                  />
+                </div>
               }
               <StaffSlipEditList staffSlips={staffSlips} />
             </Accordion>

--- a/test/bigtest/interactors/service-point-create.js
+++ b/test/bigtest/interactors/service-point-create.js
@@ -4,12 +4,14 @@ import {
   text,
   clickable,
   property,
+  selectable,
 } from '@bigtest/interactor';
 
 @interactor class ServicePointCreatePage {
   title = text('[class*=paneTitleLabel---]');
   pickupLocationSelect = isPresent('[data-test-pickup-location]');
-  clickpickupLocationSelectDropdown = clickable('[data-test-pickup-location]');
+  choosePickupLocation = selectable('[data-test-pickup-location]');
+  holdShelfExpirationPeriodPresent = isPresent('[data-test-holdshelfexpiry]');
 
   holdSlipCheckboxPresent = isPresent('#staff-slip-checkbox-0');
   clickHoldSlipCheckbox = clickable('#staff-slip-checkbox-0');

--- a/test/bigtest/interactors/service-point-show.js
+++ b/test/bigtest/interactors/service-point-show.js
@@ -1,10 +1,12 @@
 import {
   interactor,
   collection,
+  isPresent
 } from '@bigtest/interactor';
 
 @interactor class ServicePointShowPage {
   holdSlipList = collection('[data-test-staff-slip-list] li');
+  holdShelfPeriodPresent = isPresent('[data-test-hold-shelf-expiry-period]');
 }
 
 export default new ServicePointShowPage('[data-test-service-point-details]');

--- a/test/bigtest/tests/service-point-create-test.js
+++ b/test/bigtest/tests/service-point-create-test.js
@@ -41,4 +41,26 @@ describe('ServicePointCreate', () => {
       expect(ServicePointCreatePage.isHoldSlipChecked).to.be.true;
     });
   });
+
+  describe('toggling pickup location', () => {
+    describe('set pickup location to Yes', () => {
+      beforeEach(async function () {
+        await ServicePointCreatePage.choosePickupLocation('Yes');
+      });
+
+      it('shows hold shelf expiration period', () => {
+        expect(ServicePointCreatePage.holdShelfExpirationPeriodPresent).to.be.true;
+      });
+    });
+
+    describe('set pickup location to No', () => {
+      beforeEach(async function () {
+        await ServicePointCreatePage.choosePickupLocation('No');
+      });
+
+      it('hides hold shelf expiration period', () => {
+        expect(ServicePointCreatePage.holdShelfExpirationPeriodPresent).to.be.false;
+      });
+    });
+  });
 });

--- a/test/bigtest/tests/service-point-show-test.js
+++ b/test/bigtest/tests/service-point-show-test.js
@@ -7,16 +7,32 @@ describe('ServicePointShow', () => {
   setupApplication();
   let servicePoint;
 
-  beforeEach(function () {
-    servicePoint = this.server.create('servicePoint');
+  describe('displaying staff slip', () => {
+    beforeEach(function () {
+      servicePoint = this.server.create('servicePoint');
+      this.visit(`/settings/organization/servicePoints/${servicePoint.id}`);
+    });
+
+    it('displays staff slips', () => {
+      expect(ServicePointShowPage.holdSlipList(0).text).to.equal('Hold - yes');
+      expect(ServicePointShowPage.holdSlipList(1).text).to.equal('Transit - no');
+    });
   });
 
-  beforeEach(function () {
-    this.visit(`/settings/organization/servicePoints/${servicePoint.id}`);
-  });
+  describe('showing hold shelf expiry period', () => {
+    beforeEach(function () {
+      servicePoint = this.server.create('servicePoint', {
+        pickupLocation: true,
+        holdShelfExpiryPeriod: {
+          duration: 2,
+          intervalId: 'Days',
+        },
+      });
+      this.visit(`/settings/organization/servicePoints/${servicePoint.id}`);
+    });
 
-  it('displays staff slips', () => {
-    expect(ServicePointShowPage.holdSlipList(0).text).to.equal('Hold - yes');
-    expect(ServicePointShowPage.holdSlipList(1).text).to.equal('Transit - no');
+    it('shows hold shelf expiry period', () => {
+      expect(ServicePointShowPage.holdShelfPeriodPresent).to.be.true;
+    });
   });
 });


### PR DESCRIPTION
## Purpose
To add a hold shelf expiration period to the service points where pickup location/service point = yes. This will be used as the default expiration period for items on the hold shelf at the service point.

## Notes
Part of this work has been done under: https://github.com/folio-org/ui-organization/pull/204 by @aditya-matukumalli. This PR adds ability to see hold shelf expiry period on the service point details screen. It also adds more tests.  

## Link
https://issues.folio.org/browse/UIORG-143

## Screenshot
![period](https://user-images.githubusercontent.com/63545/52437682-817f6d00-2ae5-11e9-93e0-b5927d93ca98.gif)
